### PR TITLE
Make Fast admin styles more targeted

### DIFF
--- a/includes/fast-plugin-settings.php
+++ b/includes/fast-plugin-settings.php
@@ -244,7 +244,7 @@ function fast_settings_admin_notice_woocommerce_not_installed() {
  */
 function fast_settings_page_content() {
 	?>
-		<div class="wrap">
+		<div class="wrap fast-settings">
 			<h2>Fast Settings</h2>
 			<form method="post" action="options.php">
 				<?php
@@ -445,17 +445,21 @@ function fast_admin_styles() {
 	}
 	?>
 		<style>
-			body, td, textarea, input, select {
+			.fast-settings,
+			.fast-settings td,
+			.fast-settings textarea,
+			.fast-settings input,
+			.fast-settings select {
 				font-family: "Lucida Grande";
 				font-size: 12px;
 			}
 			@media screen and (min-width: 783px) {
-				.input-field {
+				.fast-settings .input-field {
 					min-height: 40px;
 					width: 400px;
 				}
 			}
-			textarea {
+			.fast-settings textarea {
 				resize: none;
 			}
 		</style>


### PR DESCRIPTION
# Description

Some sellers were complaining about the Fast plugin changing the fonts in the WordPress admin. This update makes the Fast admin styles more targeted to just the `<div>` that wraps the Fast settings. It adds a class of `fast-settings` to the wrapper `<div>` and then updates the selectors in the CSS to include the `.fast-settings` class.

# Testing instructions

This code is up on the Fast dev site: https://fasttestdev.wpcomstaging.com/

1. Open the Fast [settings page in the WP admin](https://fasttestdev.wpcomstaging.com/wp-admin/admin.php?page=fast).
2. Verify that the WP admin bar and sidebar nav elements do not have "Lucida Grande" as their font family.
3. Verify that the Fast settings form does use "Lucida Grande" as its font family.

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`