### PR TITLE
Shipping Options endpoint single address validation fix

### DIFF
--- a/includes/routes/shipping.php
+++ b/includes/routes/shipping.php
@@ -150,7 +150,12 @@ function fast_shipping_calculate_packages() {
 
 	// Currently we only support 1 shipping address per package.
 	if ( count( $packages ) > 1 ) {
-		return new WP_Error( 'shipping_packages', 'Shipping package to > 1 address is not supported', array( 'status' => 400 ) );
+		// Perform address check to make sure all are the same
+		for ($x = 1; $x < count ( $packages ); $x++) {
+  			if($packages[0]->destination != $packages[$x]->destination){
+				return new WP_Error( 'shipping_packages', 'Shipping package to > 1 address is not supported', array( 'status' => 400 ) );
+			}
+		}
 	}
 
 	// Add package ID to array.

--- a/includes/routes/shipping.php
+++ b/includes/routes/shipping.php
@@ -152,7 +152,7 @@ function fast_shipping_calculate_packages() {
 	if ( count( $packages ) > 1 ) {
 		// Perform address check to make sure all are the same
 		for ( $x = 1; $x < count( $packages ); $x++ ) {
-			if ( $packages[0]->destination != $packages[ $x ]->destination ) {
+			if ( $packages[0]->destination !== $packages[ $x ]->destination ) {
 				return new WP_Error( 'shipping_packages', 'Shipping package to > 1 address is not supported', array( 'status' => 400 ) );
 			}
 		}

--- a/includes/routes/shipping.php
+++ b/includes/routes/shipping.php
@@ -151,8 +151,8 @@ function fast_shipping_calculate_packages() {
 	// Currently we only support 1 shipping address per package.
 	if ( count( $packages ) > 1 ) {
 		// Perform address check to make sure all are the same
-		for ($x = 1; $x < count ( $packages ); $x++) {
-  			if($packages[0]->destination != $packages[$x]->destination){
+		for ( $x = 1; $x < count( $packages ); $x++ ) {
+			if ( $packages[0]->destination != $packages[ $x ]->destination ) {
 				return new WP_Error( 'shipping_packages', 'Shipping package to > 1 address is not supported', array( 'status' => 400 ) );
 			}
 		}


### PR DESCRIPTION
# Description
Current validation assumes that if multiple packages we also have multiple addresses. I switched the validation for cases with multiple packages to ensure they are the same before proceeding.

# Testing instructions
Call the shipping endpoint for a specific item with promotion packages and if the addresses are the same the response should contain available shipping options.

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`