### PR TITLE
Update prefixes

### DIFF
--- a/fast.php
+++ b/fast.php
@@ -10,19 +10,19 @@
  * @package Fast
  */
 
-define( 'FAST_PATH', plugin_dir_path( __FILE__ ) );
+define( 'FASTWC_PATH', plugin_dir_path( __FILE__ ) );
 
 // WP Admin plugin settings.
-require_once FAST_PATH . 'includes/admin/settings.php';
+require_once FASTWC_PATH . 'includes/admin/settings.php';
 // Loads fast.js.
-require_once FAST_PATH . 'includes/js.php';
+require_once FASTWC_PATH . 'includes/js.php';
 // Loads fast utilities.
-require_once FAST_PATH . 'includes/utilities.php';
+require_once FASTWC_PATH . 'includes/utilities.php';
 // Adds Fast Checkout button to store.
-require_once FAST_PATH . 'includes/checkout.php';
+require_once FASTWC_PATH . 'includes/checkout.php';
 // Adds Fast Login button to store.
-require_once FAST_PATH . 'includes/login.php';
+require_once FASTWC_PATH . 'includes/login.php';
 // Registers routes for the plugin API endpoints.
-require_once FAST_PATH . 'includes/routes.php';
+require_once FASTWC_PATH . 'includes/routes.php';
 // Add Fast button shortcodes.
-require_once FAST_PATH . 'includes/shortcodes.php';
+require_once FASTWC_PATH . 'includes/shortcodes.php';

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -7,23 +7,23 @@
  * @package Fast
  */
 
-define( 'FAST_SETTING_APP_ID', 'fast_app_id' );
-define( 'FAST_SETTING_TEST_MODE', 'fast_test_mode' );
-define( 'FAST_SETTING_TEST_MODE_NOT_SET', 'fast test mode not set' );
-define( 'FAST_SETTING_FAST_JS_URL', 'fast_fast_js_url' );
-define( 'FAST_SETTING_FAST_JWKS_URL', 'fast_fast_jwks_url' );
-define( 'FAST_SETTING_ONBOARDING_URL', 'fast_onboarding_url' );
-define( 'FAST_SETTING_PDP_BUTTON_STYLES', 'fast_pdp_button_styles' );
-define( 'FAST_SETTING_CART_BUTTON_STYLES', 'fast_cart_button_styles' );
-define( 'FAST_SETTING_MINI_CART_BUTTON_STYLES', 'fast_mini_cart_button_styles' );
-define( 'FAST_SETTING_CHECKOUT_BUTTON_STYLES', 'fast_checkout_button_styles' );
-define( 'FAST_SETTING_LOGIN_BUTTON_STYLES', 'fast_login_button_styles' );
-define( 'FAST_JWKS_URL', 'https://api.fast.co/v1/oauth2/jwks' );
-define( 'FAST_JS_URL', 'https://js.fast.co/fast-woocommerce.js' );
-define( 'FAST_ONBOARDING_URL', 'https://fast.co/business' );
+define( 'FASTWC_SETTING_APP_ID', 'fast_app_id' );
+define( 'FASTWC_SETTING_TEST_MODE', 'fast_test_mode' );
+define( 'FASTWC_SETTING_TEST_MODE_NOT_SET', 'fast test mode not set' );
+define( 'FASTWC_SETTING_FAST_JS_URL', 'fast_fast_js_url' );
+define( 'FASTWC_SETTING_FAST_JWKS_URL', 'fast_fast_jwks_url' );
+define( 'FASTWC_SETTING_ONBOARDING_URL', 'fast_onboarding_url' );
+define( 'FASTWC_SETTING_PDP_BUTTON_STYLES', 'fast_pdp_button_styles' );
+define( 'FASTWC_SETTING_CART_BUTTON_STYLES', 'fast_cart_button_styles' );
+define( 'FASTWC_SETTING_MINI_CART_BUTTON_STYLES', 'fast_mini_cart_button_styles' );
+define( 'FASTWC_SETTING_CHECKOUT_BUTTON_STYLES', 'fast_checkout_button_styles' );
+define( 'FASTWC_SETTING_LOGIN_BUTTON_STYLES', 'fast_login_button_styles' );
+define( 'FASTWC_JWKS_URL', 'https://api.fast.co/v1/oauth2/jwks' );
+define( 'FASTWC_JS_URL', 'https://js.fast.co/fast-woocommerce.js' );
+define( 'FASTWC_ONBOARDING_URL', 'https://fast.co/business' );
 
 define(
-	'FAST_SETTING_PDP_BUTTON_STYLES_DEFAULT',
+	'FASTWC_SETTING_PDP_BUTTON_STYLES_DEFAULT',
 	<<<CSS
 .fast-pdp-wrapper {
   padding: 21px 0 20px 0;
@@ -64,7 +64,7 @@ CSS
 );
 
 define(
-	'FAST_SETTING_CART_BUTTON_STYLES_DEFAULT',
+	'FASTWC_SETTING_CART_BUTTON_STYLES_DEFAULT',
 	<<<CSS
 .fast-cart-wrapper {
   padding: 21px 0 20px 0;
@@ -105,7 +105,7 @@ CSS
 );
 
 define(
-	'FAST_SETTING_MINI_CART_BUTTON_STYLES_DEFAULT',
+	'FASTWC_SETTING_MINI_CART_BUTTON_STYLES_DEFAULT',
 	<<<CSS
 .fast-mini-cart-wrapper {
   height: 68px;
@@ -127,7 +127,7 @@ CSS
 );
 
 define(
-	'FAST_SETTING_CHECKOUT_BUTTON_STYLES_DEFAULT',
+	'FASTWC_SETTING_CHECKOUT_BUTTON_STYLES_DEFAULT',
 	<<<CSS
 .fast-checkout-wrapper {
   padding: 21px 0 20px 0;
@@ -168,7 +168,7 @@ CSS
 );
 
 define(
-	'FAST_SETTING_LOGIN_BUTTON_STYLES_DEFAULT',
+	'FASTWC_SETTING_LOGIN_BUTTON_STYLES_DEFAULT',
 	<<<CSS
 .fast-login-wrapper {
   border: 1.25px solid #d3ced2;
@@ -214,16 +214,16 @@ function fastwc_admin_create_menu() {
 	$position   = 100;
 
 	add_menu_page( $page_title, $menu_title, $capability, $slug, $callback, $icon, $position );
-	register_setting( 'fast', FAST_SETTING_APP_ID );
-	register_setting( 'fast', FAST_SETTING_PDP_BUTTON_STYLES );
-	register_setting( 'fast', FAST_SETTING_CART_BUTTON_STYLES );
-	register_setting( 'fast', FAST_SETTING_MINI_CART_BUTTON_STYLES );
-	register_setting( 'fast', FAST_SETTING_CHECKOUT_BUTTON_STYLES );
-	register_setting( 'fast', FAST_SETTING_LOGIN_BUTTON_STYLES );
-	register_setting( 'fast', FAST_SETTING_TEST_MODE );
-	register_setting( 'fast', FAST_SETTING_FAST_JS_URL );
-	register_setting( 'fast', FAST_SETTING_FAST_JWKS_URL );
-	register_setting( 'fast', FAST_SETTING_ONBOARDING_URL );
+	register_setting( 'fast', FASTWC_SETTING_APP_ID );
+	register_setting( 'fast', FASTWC_SETTING_PDP_BUTTON_STYLES );
+	register_setting( 'fast', FASTWC_SETTING_CART_BUTTON_STYLES );
+	register_setting( 'fast', FASTWC_SETTING_MINI_CART_BUTTON_STYLES );
+	register_setting( 'fast', FASTWC_SETTING_CHECKOUT_BUTTON_STYLES );
+	register_setting( 'fast', FASTWC_SETTING_LOGIN_BUTTON_STYLES );
+	register_setting( 'fast', FASTWC_SETTING_TEST_MODE );
+	register_setting( 'fast', FASTWC_SETTING_FAST_JS_URL );
+	register_setting( 'fast', FASTWC_SETTING_FAST_JWKS_URL );
+	register_setting( 'fast', FASTWC_SETTING_ONBOARDING_URL );
 
 	// Check whether the woocommerce plugin is active.
 	$active_plugins = apply_filters( 'active_plugins', get_option( 'active_plugins' ) );
@@ -275,19 +275,19 @@ function fastwc_admin_setup_sections() {
  * Sets up fields for Fast settings page.
  */
 function fastwc_admin_setup_fields() {
-	add_settings_field( FAST_SETTING_APP_ID, 'App ID', 'fastwc_app_id_content', 'fast', 'fast_app_info' );
+	add_settings_field( FASTWC_SETTING_APP_ID, 'App ID', 'fastwc_app_id_content', 'fast', 'fast_app_info' );
 
-	add_settings_field( FAST_SETTING_PDP_BUTTON_STYLES, 'Product page button styles', 'fastwc_pdp_button_styles_content', 'fast', 'fast_styles' );
-	add_settings_field( FAST_SETTING_CART_BUTTON_STYLES, 'Cart page button styles', 'fastwc_cart_button_styles_content', 'fast', 'fast_styles' );
-	add_settings_field( FAST_SETTING_MINI_CART_BUTTON_STYLES, 'Mini cart widget button styles', 'fastwc_mini_cart_button_styles_content', 'fast', 'fast_styles' );
-	add_settings_field( FAST_SETTING_CHECKOUT_BUTTON_STYLES, 'Checkout page button styles', 'fastwc_checkout_button_styles_content', 'fast', 'fast_styles' );
-	add_settings_field( FAST_SETTING_LOGIN_BUTTON_STYLES, 'Login button styles', 'fastwc_login_button_styles_content', 'fast', 'fast_styles' );
+	add_settings_field( FASTWC_SETTING_PDP_BUTTON_STYLES, 'Product page button styles', 'fastwc_pdp_button_styles_content', 'fast', 'fast_styles' );
+	add_settings_field( FASTWC_SETTING_CART_BUTTON_STYLES, 'Cart page button styles', 'fastwc_cart_button_styles_content', 'fast', 'fast_styles' );
+	add_settings_field( FASTWC_SETTING_MINI_CART_BUTTON_STYLES, 'Mini cart widget button styles', 'fastwc_mini_cart_button_styles_content', 'fast', 'fast_styles' );
+	add_settings_field( FASTWC_SETTING_CHECKOUT_BUTTON_STYLES, 'Checkout page button styles', 'fastwc_checkout_button_styles_content', 'fast', 'fast_styles' );
+	add_settings_field( FASTWC_SETTING_LOGIN_BUTTON_STYLES, 'Login button styles', 'fastwc_login_button_styles_content', 'fast', 'fast_styles' );
 
-	add_settings_field( FAST_SETTING_TEST_MODE, 'Test Mode', 'fastwc_test_mode_content', 'fast', 'fast_test_mode' );
+	add_settings_field( FASTWC_SETTING_TEST_MODE, 'Test Mode', 'fastwc_test_mode_content', 'fast', 'fast_test_mode' );
 
-	add_settings_field( FAST_SETTING_FAST_JS_URL, 'Fast JS URL', 'fastwc_fastwc_js_content', 'fast', 'fast_advanced' );
-	add_settings_field( FAST_SETTING_FAST_JWKS_URL, 'Fast JWKS URL', 'fastwc_fastwc_jwks_content', 'fast', 'fast_advanced' );
-	add_settings_field( FAST_SETTING_ONBOARDING_URL, 'Fast Onboarding URL', 'fastwc_onboarding_url_content', 'fast', 'fast_advanced' );
+	add_settings_field( FASTWC_SETTING_FAST_JS_URL, 'Fast JS URL', 'fastwc_fastwc_js_content', 'fast', 'fast_advanced' );
+	add_settings_field( FASTWC_SETTING_FAST_JWKS_URL, 'Fast JWKS URL', 'fastwc_fastwc_jwks_content', 'fast', 'fast_advanced' );
+	add_settings_field( FASTWC_SETTING_ONBOARDING_URL, 'Fast Onboarding URL', 'fastwc_onboarding_url_content', 'fast', 'fast_advanced' );
 }
 
 /**
@@ -295,7 +295,7 @@ function fastwc_admin_setup_fields() {
  */
 function fastwc_app_id_content() {
 	$fastwc_setting_app_id              = fastwc_get_app_id();
-	$fastwc_setting_fast_onboarding_url = fastwc_get_option_or_set_default( FAST_SETTING_ONBOARDING_URL, FAST_ONBOARDING_URL );
+	$fastwc_setting_fast_onboarding_url = fastwc_get_option_or_set_default( FASTWC_SETTING_ONBOARDING_URL, FASTWC_ONBOARDING_URL );
 	?>
 		<input
 			name="fast_app_id"
@@ -312,7 +312,7 @@ function fastwc_app_id_content() {
  * Renders the PDP button styles field.
  */
 function fastwc_pdp_button_styles_content() {
-	$fastwc_setting_pdp_button_styles = fastwc_get_option_or_set_default( FAST_SETTING_PDP_BUTTON_STYLES, FAST_SETTING_PDP_BUTTON_STYLES_DEFAULT );
+	$fastwc_setting_pdp_button_styles = fastwc_get_option_or_set_default( FASTWC_SETTING_PDP_BUTTON_STYLES, FASTWC_SETTING_PDP_BUTTON_STYLES_DEFAULT );
 	?>
 		<textarea name="fast_pdp_button_styles" id="fast_pdp_button_styles" rows="10" cols="50"><?php echo esc_textarea( $fastwc_setting_pdp_button_styles ); ?></textarea>
 	<?php
@@ -322,7 +322,7 @@ function fastwc_pdp_button_styles_content() {
  * Renders the cart button styles field.
  */
 function fastwc_cart_button_styles_content() {
-	$fastwc_setting_cart_button_styles = fastwc_get_option_or_set_default( FAST_SETTING_CART_BUTTON_STYLES, FAST_SETTING_CART_BUTTON_STYLES_DEFAULT );
+	$fastwc_setting_cart_button_styles = fastwc_get_option_or_set_default( FASTWC_SETTING_CART_BUTTON_STYLES, FASTWC_SETTING_CART_BUTTON_STYLES_DEFAULT );
 	?>
 		<textarea name="fast_cart_button_styles" id="fast_cart_button_styles" rows="10" cols="50"><?php echo esc_textarea( $fastwc_setting_cart_button_styles ); ?></textarea>
 	<?php
@@ -332,7 +332,7 @@ function fastwc_cart_button_styles_content() {
  * Renders the mini-cart button styles field.
  */
 function fastwc_mini_cart_button_styles_content() {
-	$fastwc_setting_mini_cart_button_styles = fastwc_get_option_or_set_default( FAST_SETTING_MINI_CART_BUTTON_STYLES, FAST_SETTING_MINI_CART_BUTTON_STYLES_DEFAULT );
+	$fastwc_setting_mini_cart_button_styles = fastwc_get_option_or_set_default( FASTWC_SETTING_MINI_CART_BUTTON_STYLES, FASTWC_SETTING_MINI_CART_BUTTON_STYLES_DEFAULT );
 	?>
 		<textarea name="fast_mini_cart_button_styles" id="fast_mini_cart_button_styles" rows="10" cols="50"><?php echo esc_textarea( $fastwc_setting_mini_cart_button_styles ); ?></textarea>
 	<?php
@@ -342,7 +342,7 @@ function fastwc_mini_cart_button_styles_content() {
  * Renders the checkout button styles field.
  */
 function fastwc_checkout_button_styles_content() {
-	$fastwc_setting_checkout_button_styles = fastwc_get_option_or_set_default( FAST_SETTING_CHECKOUT_BUTTON_STYLES, FAST_SETTING_CHECKOUT_BUTTON_STYLES_DEFAULT );
+	$fastwc_setting_checkout_button_styles = fastwc_get_option_or_set_default( FASTWC_SETTING_CHECKOUT_BUTTON_STYLES, FASTWC_SETTING_CHECKOUT_BUTTON_STYLES_DEFAULT );
 	?>
 		<textarea name="fast_checkout_button_styles" id="fast_checkout_button_styles" rows="10" cols="50"><?php echo esc_textarea( $fastwc_setting_checkout_button_styles ); ?></textarea>
 	<?php
@@ -352,7 +352,7 @@ function fastwc_checkout_button_styles_content() {
  * Renders the login button styles field.
  */
 function fastwc_login_button_styles_content() {
-	$fastwc_setting_login_button_styles = fastwc_get_option_or_set_default( FAST_SETTING_LOGIN_BUTTON_STYLES, FAST_SETTING_LOGIN_BUTTON_STYLES_DEFAULT );
+	$fastwc_setting_login_button_styles = fastwc_get_option_or_set_default( FASTWC_SETTING_LOGIN_BUTTON_STYLES, FASTWC_SETTING_LOGIN_BUTTON_STYLES_DEFAULT );
 	?>
 		<textarea name="fast_login_button_styles" id="fast_login_button_styles" rows="10" cols="50"><?php echo esc_textarea( $fastwc_setting_login_button_styles ); ?></textarea>
 	<?php
@@ -362,13 +362,13 @@ function fastwc_login_button_styles_content() {
  * Renders the Test Mode field.
  */
 function fastwc_test_mode_content() {
-	$fastwc_test_mode = get_option( FAST_SETTING_TEST_MODE, FAST_SETTING_TEST_MODE_NOT_SET );
+	$fastwc_test_mode = get_option( FASTWC_SETTING_TEST_MODE, FASTWC_SETTING_TEST_MODE_NOT_SET );
 
-	if ( FAST_SETTING_TEST_MODE_NOT_SET === $fastwc_test_mode ) {
-		// If the option is FAST_SETTING_TEST_MODE_NOT_SET, then it hasn't yet been set. In this case, we
+	if ( FASTWC_SETTING_TEST_MODE_NOT_SET === $fastwc_test_mode ) {
+		// If the option is FASTWC_SETTING_TEST_MODE_NOT_SET, then it hasn't yet been set. In this case, we
 		// want to configure test mode to be on.
 		$fastwc_test_mode = '1';
-		update_option( FAST_SETTING_TEST_MODE, '1' );
+		update_option( FASTWC_SETTING_TEST_MODE, '1' );
 	}
 
 	?>
@@ -390,7 +390,7 @@ function fastwc_test_mode_content() {
  * Renders the fast.js URL field.
  */
 function fastwc_fastwc_js_content() {
-	$fastwc_setting_fast_js_url = fastwc_get_option_or_set_default( FAST_SETTING_FAST_JS_URL, FAST_JS_URL );
+	$fastwc_setting_fast_js_url = fastwc_get_option_or_set_default( FASTWC_SETTING_FAST_JS_URL, FASTWC_JS_URL );
 	?>
 		<input
 		name="fast_fast_js_url"
@@ -406,7 +406,7 @@ function fastwc_fastwc_js_content() {
  * Renders the Fast JWKS URL field.
  */
 function fastwc_fastwc_jwks_content() {
-	$fastwc_setting_fast_jwks_url = fastwc_get_option_or_set_default( FAST_SETTING_FAST_JWKS_URL, FAST_JWKS_URL );
+	$fastwc_setting_fast_jwks_url = fastwc_get_option_or_set_default( FASTWC_SETTING_FAST_JWKS_URL, FASTWC_JWKS_URL );
 	?>
 		<input
 			name="fast_fast_jwks_url"
@@ -422,7 +422,7 @@ function fastwc_fastwc_jwks_content() {
  * Renders the onboarding URL field.
  */
 function fastwc_onboarding_url_content() {
-	$url = fastwc_get_option_or_set_default( FAST_SETTING_ONBOARDING_URL, FAST_ONBOARDING_URL );
+	$url = fastwc_get_option_or_set_default( FASTWC_SETTING_ONBOARDING_URL, FASTWC_ONBOARDING_URL );
 	?>
 		<input
 			name="fast_onboarding_url"
@@ -491,5 +491,5 @@ function fastwc_get_option_or_set_default( $option, $default ) {
  * @return string
  */
 function fastwc_get_app_id() {
-	return get_option( FAST_SETTING_APP_ID );
+	return get_option( FASTWC_SETTING_APP_ID );
 }

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -195,21 +195,21 @@ define(
 CSS
 );
 
-add_action( 'admin_head', 'fast_admin_styles' );
-add_action( 'admin_menu', 'fast_admin_create_menu' );
-add_action( 'admin_init', 'fast_admin_setup_sections' );
-add_action( 'admin_init', 'fast_admin_setup_fields' );
+add_action( 'admin_head', 'fastwc_admin_styles' );
+add_action( 'admin_menu', 'fastwc_admin_create_menu' );
+add_action( 'admin_init', 'fastwc_admin_setup_sections' );
+add_action( 'admin_init', 'fastwc_admin_setup_fields' );
 
 /**
  * Registers the Fast menu within wp-admin.
  */
-function fast_admin_create_menu() {
+function fastwc_admin_create_menu() {
 	// Add the menu item and page.
 	$page_title = 'Fast Settings';
 	$menu_title = 'Fast';
 	$capability = 'manage_options';
 	$slug       = 'fast';
-	$callback   = 'fast_settings_page_content';
+	$callback   = 'fastwc_settings_page_content';
 	$icon       = 'data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB3aWR0aD0iMjM4cHgiIGhlaWdodD0iMjM4cHgiIHZpZXdCb3g9IjAgMCAyMzggMjM4IiB2ZXJzaW9uPSIxLjEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiPgogICAgPHRpdGxlPkFydGJvYXJkPC90aXRsZT4KICAgIDxnIGlkPSJQYWdlLTEiIHN0cm9rZT0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIxIiBmaWxsPSJub25lIiBmaWxsLXJ1bGU9ImV2ZW5vZGQiPgogICAgICAgIDxnIGlkPSJBcnRib2FyZCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTEwOC4wMDAwMDAsIC02Ny4wMDAwMDApIiBmaWxsPSIjRkZGRkZGIiBmaWxsLXJ1bGU9Im5vbnplcm8iPgogICAgICAgICAgICA8cGF0aCBkPSJNMjc5LjYxMjEzOSwxMjkuODA5NTMxIEwyMDcuMTMzMTkzLDEyOS44MDk1MzEgTDIwNy4xMzMxOTMsMTcwLjA0NzY1OSBMMjY5Ljk0Nzk4MiwxNzAuMDQ3NjU5IEwyNjkuOTQ3OTgyLDE5OC44NTczMzQgTDIwNy4xMzMxOTMsMTk4Ljg1NzMzNCBMMjA3LjEzMzE5MywyNzEgTDE3NCwyNzEgTDE3NCwxMTQuODA5NTYxIEMxNzQsMTEwLjY4MjUyMyAxNzUuMzgwNTUzLDEwNy4zNDkyMSAxNzguMTQxNjUxLDEwNC44MDk1MzUgQzE4MC45MDI3NTYsMTAyLjI2OTg0NSAxODQuMjAwNzM1LDEwMSAxODguMDM1NTcxLDEwMSBMMjc5LjYxMjEzOSwxMDEgTDI3OS42MTIxMzksMTI5LjgwOTUzMSBaIiBpZD0iUGF0aCI+PC9wYXRoPgogICAgICAgIDwvZz4KICAgIDwvZz4KPC9zdmc+';
 	$position   = 100;
 
@@ -228,21 +228,21 @@ function fast_admin_create_menu() {
 	// Check whether the woocommerce plugin is active.
 	$active_plugins = apply_filters( 'active_plugins', get_option( 'active_plugins' ) );
 	if ( ! in_array( 'woocommerce/woocommerce.php', $active_plugins, true ) ) {
-		add_action( 'admin_notices', 'fast_settings_admin_notice_woocommerce_not_installed' );
+		add_action( 'admin_notices', 'fastwc_settings_admin_notice_woocommerce_not_installed' );
 	}
 }
 
 /**
  * Prints the error message when woocommerce isn't installed.
  */
-function fast_settings_admin_notice_woocommerce_not_installed() {
+function fastwc_settings_admin_notice_woocommerce_not_installed() {
 	printf( '<div class="notice notice-error"><p>Your Fast plugin won\'t work without an active WooCommerce installation.</p></div>' );
 }
 
 /**
  * Renders content of Fast settings page.
  */
-function fast_settings_page_content() {
+function fastwc_settings_page_content() {
 	?>
 		<div class="wrap fast-settings">
 			<h2>Fast Settings</h2>
@@ -260,7 +260,7 @@ function fast_settings_page_content() {
 /**
  * Sets up sections for Fast settings page.
  */
-function fast_admin_setup_sections() {
+function fastwc_admin_setup_sections() {
 	add_settings_section( 'fast_app_info', 'App Info', false, 'fast' );
 	add_settings_section( 'fast_styles', 'Button Styles', false, 'fast' );
 	add_settings_section( 'fast_test_mode', 'Test Mode', false, 'fast' );
@@ -274,100 +274,100 @@ function fast_admin_setup_sections() {
 /**
  * Sets up fields for Fast settings page.
  */
-function fast_admin_setup_fields() {
-	add_settings_field( FAST_SETTING_APP_ID, 'App ID', 'fast_app_id_content', 'fast', 'fast_app_info' );
+function fastwc_admin_setup_fields() {
+	add_settings_field( FAST_SETTING_APP_ID, 'App ID', 'fastwc_app_id_content', 'fast', 'fast_app_info' );
 
-	add_settings_field( FAST_SETTING_PDP_BUTTON_STYLES, 'Product page button styles', 'fast_pdp_button_styles_content', 'fast', 'fast_styles' );
-	add_settings_field( FAST_SETTING_CART_BUTTON_STYLES, 'Cart page button styles', 'fast_cart_button_styles_content', 'fast', 'fast_styles' );
-	add_settings_field( FAST_SETTING_MINI_CART_BUTTON_STYLES, 'Mini cart widget button styles', 'fast_mini_cart_button_styles_content', 'fast', 'fast_styles' );
-	add_settings_field( FAST_SETTING_CHECKOUT_BUTTON_STYLES, 'Checkout page button styles', 'fast_checkout_button_styles_content', 'fast', 'fast_styles' );
-	add_settings_field( FAST_SETTING_LOGIN_BUTTON_STYLES, 'Login button styles', 'fast_login_button_styles_content', 'fast', 'fast_styles' );
+	add_settings_field( FAST_SETTING_PDP_BUTTON_STYLES, 'Product page button styles', 'fastwc_pdp_button_styles_content', 'fast', 'fast_styles' );
+	add_settings_field( FAST_SETTING_CART_BUTTON_STYLES, 'Cart page button styles', 'fastwc_cart_button_styles_content', 'fast', 'fast_styles' );
+	add_settings_field( FAST_SETTING_MINI_CART_BUTTON_STYLES, 'Mini cart widget button styles', 'fastwc_mini_cart_button_styles_content', 'fast', 'fast_styles' );
+	add_settings_field( FAST_SETTING_CHECKOUT_BUTTON_STYLES, 'Checkout page button styles', 'fastwc_checkout_button_styles_content', 'fast', 'fast_styles' );
+	add_settings_field( FAST_SETTING_LOGIN_BUTTON_STYLES, 'Login button styles', 'fastwc_login_button_styles_content', 'fast', 'fast_styles' );
 
-	add_settings_field( FAST_SETTING_TEST_MODE, 'Test Mode', 'fast_test_mode_content', 'fast', 'fast_test_mode' );
+	add_settings_field( FAST_SETTING_TEST_MODE, 'Test Mode', 'fastwc_test_mode_content', 'fast', 'fast_test_mode' );
 
-	add_settings_field( FAST_SETTING_FAST_JS_URL, 'Fast JS URL', 'fast_fast_js_content', 'fast', 'fast_advanced' );
-	add_settings_field( FAST_SETTING_FAST_JWKS_URL, 'Fast JWKS URL', 'fast_fast_jwks_content', 'fast', 'fast_advanced' );
-	add_settings_field( FAST_SETTING_ONBOARDING_URL, 'Fast Onboarding URL', 'fast_onboarding_url_content', 'fast', 'fast_advanced' );
+	add_settings_field( FAST_SETTING_FAST_JS_URL, 'Fast JS URL', 'fastwc_fastwc_js_content', 'fast', 'fast_advanced' );
+	add_settings_field( FAST_SETTING_FAST_JWKS_URL, 'Fast JWKS URL', 'fastwc_fastwc_jwks_content', 'fast', 'fast_advanced' );
+	add_settings_field( FAST_SETTING_ONBOARDING_URL, 'Fast Onboarding URL', 'fastwc_onboarding_url_content', 'fast', 'fast_advanced' );
 }
 
 /**
  * Renders the App ID field.
  */
-function fast_app_id_content() {
-	$fast_setting_app_id              = fast_get_app_id();
-	$fast_setting_fast_onboarding_url = fast_get_option_or_set_default( FAST_SETTING_ONBOARDING_URL, FAST_ONBOARDING_URL );
+function fastwc_app_id_content() {
+	$fastwc_setting_app_id              = fastwc_get_app_id();
+	$fastwc_setting_fast_onboarding_url = fastwc_get_option_or_set_default( FAST_SETTING_ONBOARDING_URL, FAST_ONBOARDING_URL );
 	?>
 		<input
 			name="fast_app_id"
 			id="fast_app_id"
 			type="text"
 			class="input-field"
-			value="<?php echo esc_attr( $fast_setting_app_id ); ?>"
+			value="<?php echo esc_attr( $fastwc_setting_app_id ); ?>"
 		/>
-		<p>Don't have an app yet? Click <a href="<?php echo esc_url( $fast_setting_fast_onboarding_url ); ?>" target="_blank" rel="noopener">here</a> to create one.</p>
+		<p>Don't have an app yet? Click <a href="<?php echo esc_url( $fastwc_setting_fast_onboarding_url ); ?>" target="_blank" rel="noopener">here</a> to create one.</p>
 	<?php
 }
 
 /**
  * Renders the PDP button styles field.
  */
-function fast_pdp_button_styles_content() {
-	$fast_setting_pdp_button_styles = fast_get_option_or_set_default( FAST_SETTING_PDP_BUTTON_STYLES, FAST_SETTING_PDP_BUTTON_STYLES_DEFAULT );
+function fastwc_pdp_button_styles_content() {
+	$fastwc_setting_pdp_button_styles = fastwc_get_option_or_set_default( FAST_SETTING_PDP_BUTTON_STYLES, FAST_SETTING_PDP_BUTTON_STYLES_DEFAULT );
 	?>
-		<textarea name="fast_pdp_button_styles" id="fast_pdp_button_styles" rows="10" cols="50"><?php echo esc_textarea( $fast_setting_pdp_button_styles ); ?></textarea>
+		<textarea name="fast_pdp_button_styles" id="fast_pdp_button_styles" rows="10" cols="50"><?php echo esc_textarea( $fastwc_setting_pdp_button_styles ); ?></textarea>
 	<?php
 }
 
 /**
  * Renders the cart button styles field.
  */
-function fast_cart_button_styles_content() {
-	$fast_setting_cart_button_styles = fast_get_option_or_set_default( FAST_SETTING_CART_BUTTON_STYLES, FAST_SETTING_CART_BUTTON_STYLES_DEFAULT );
+function fastwc_cart_button_styles_content() {
+	$fastwc_setting_cart_button_styles = fastwc_get_option_or_set_default( FAST_SETTING_CART_BUTTON_STYLES, FAST_SETTING_CART_BUTTON_STYLES_DEFAULT );
 	?>
-		<textarea name="fast_cart_button_styles" id="fast_cart_button_styles" rows="10" cols="50"><?php echo esc_textarea( $fast_setting_cart_button_styles ); ?></textarea>
+		<textarea name="fast_cart_button_styles" id="fast_cart_button_styles" rows="10" cols="50"><?php echo esc_textarea( $fastwc_setting_cart_button_styles ); ?></textarea>
 	<?php
 }
 
 /**
  * Renders the mini-cart button styles field.
  */
-function fast_mini_cart_button_styles_content() {
-	$fast_setting_mini_cart_button_styles = fast_get_option_or_set_default( FAST_SETTING_MINI_CART_BUTTON_STYLES, FAST_SETTING_MINI_CART_BUTTON_STYLES_DEFAULT );
+function fastwc_mini_cart_button_styles_content() {
+	$fastwc_setting_mini_cart_button_styles = fastwc_get_option_or_set_default( FAST_SETTING_MINI_CART_BUTTON_STYLES, FAST_SETTING_MINI_CART_BUTTON_STYLES_DEFAULT );
 	?>
-		<textarea name="fast_mini_cart_button_styles" id="fast_mini_cart_button_styles" rows="10" cols="50"><?php echo esc_textarea( $fast_setting_mini_cart_button_styles ); ?></textarea>
+		<textarea name="fast_mini_cart_button_styles" id="fast_mini_cart_button_styles" rows="10" cols="50"><?php echo esc_textarea( $fastwc_setting_mini_cart_button_styles ); ?></textarea>
 	<?php
 }
 
 /**
  * Renders the checkout button styles field.
  */
-function fast_checkout_button_styles_content() {
-	$fast_setting_checkout_button_styles = fast_get_option_or_set_default( FAST_SETTING_CHECKOUT_BUTTON_STYLES, FAST_SETTING_CHECKOUT_BUTTON_STYLES_DEFAULT );
+function fastwc_checkout_button_styles_content() {
+	$fastwc_setting_checkout_button_styles = fastwc_get_option_or_set_default( FAST_SETTING_CHECKOUT_BUTTON_STYLES, FAST_SETTING_CHECKOUT_BUTTON_STYLES_DEFAULT );
 	?>
-		<textarea name="fast_checkout_button_styles" id="fast_checkout_button_styles" rows="10" cols="50"><?php echo esc_textarea( $fast_setting_checkout_button_styles ); ?></textarea>
+		<textarea name="fast_checkout_button_styles" id="fast_checkout_button_styles" rows="10" cols="50"><?php echo esc_textarea( $fastwc_setting_checkout_button_styles ); ?></textarea>
 	<?php
 }
 
 /**
  * Renders the login button styles field.
  */
-function fast_login_button_styles_content() {
-	$fast_setting_login_button_styles = fast_get_option_or_set_default( FAST_SETTING_LOGIN_BUTTON_STYLES, FAST_SETTING_LOGIN_BUTTON_STYLES_DEFAULT );
+function fastwc_login_button_styles_content() {
+	$fastwc_setting_login_button_styles = fastwc_get_option_or_set_default( FAST_SETTING_LOGIN_BUTTON_STYLES, FAST_SETTING_LOGIN_BUTTON_STYLES_DEFAULT );
 	?>
-		<textarea name="fast_login_button_styles" id="fast_login_button_styles" rows="10" cols="50"><?php echo esc_textarea( $fast_setting_login_button_styles ); ?></textarea>
+		<textarea name="fast_login_button_styles" id="fast_login_button_styles" rows="10" cols="50"><?php echo esc_textarea( $fastwc_setting_login_button_styles ); ?></textarea>
 	<?php
 }
 
 /**
  * Renders the Test Mode field.
  */
-function fast_test_mode_content() {
-	$fast_test_mode = get_option( FAST_SETTING_TEST_MODE, FAST_SETTING_TEST_MODE_NOT_SET );
+function fastwc_test_mode_content() {
+	$fastwc_test_mode = get_option( FAST_SETTING_TEST_MODE, FAST_SETTING_TEST_MODE_NOT_SET );
 
-	if ( FAST_SETTING_TEST_MODE_NOT_SET === $fast_test_mode ) {
+	if ( FAST_SETTING_TEST_MODE_NOT_SET === $fastwc_test_mode ) {
 		// If the option is FAST_SETTING_TEST_MODE_NOT_SET, then it hasn't yet been set. In this case, we
 		// want to configure test mode to be on.
-		$fast_test_mode = '1';
+		$fastwc_test_mode = '1';
 		update_option( FAST_SETTING_TEST_MODE, '1' );
 	}
 
@@ -379,7 +379,7 @@ function fast_test_mode_content() {
 				id="fast_test_mode"
 				type="checkbox"
 				value="1"
-				<?php checked( 1, $fast_test_mode ); ?>
+				<?php checked( 1, $fastwc_test_mode ); ?>
 			/>
 			<label for="fast_test_mode">Enable test mode</label>
 		</div>
@@ -389,15 +389,15 @@ function fast_test_mode_content() {
 /**
  * Renders the fast.js URL field.
  */
-function fast_fast_js_content() {
-	$fast_setting_fast_js_url = fast_get_option_or_set_default( FAST_SETTING_FAST_JS_URL, FAST_JS_URL );
+function fastwc_fastwc_js_content() {
+	$fastwc_setting_fast_js_url = fastwc_get_option_or_set_default( FAST_SETTING_FAST_JS_URL, FAST_JS_URL );
 	?>
 		<input
 		name="fast_fast_js_url"
 		id="fast_fast_js_url"
 		type="text"
 		class="input-field"
-		value="<?php echo esc_attr( $fast_setting_fast_js_url ); ?>"
+		value="<?php echo esc_attr( $fastwc_setting_fast_js_url ); ?>"
 	/>
 	<?php
 }
@@ -405,15 +405,15 @@ function fast_fast_js_content() {
 /**
  * Renders the Fast JWKS URL field.
  */
-function fast_fast_jwks_content() {
-	$fast_setting_fast_jwks_url = fast_get_option_or_set_default( FAST_SETTING_FAST_JWKS_URL, FAST_JWKS_URL );
+function fastwc_fastwc_jwks_content() {
+	$fastwc_setting_fast_jwks_url = fastwc_get_option_or_set_default( FAST_SETTING_FAST_JWKS_URL, FAST_JWKS_URL );
 	?>
 		<input
 			name="fast_fast_jwks_url"
 			id="fast_fast_jwks_url"
 			type="text"
 			class="input-field"
-			value="<?php echo esc_attr( $fast_setting_fast_jwks_url ); ?>"
+			value="<?php echo esc_attr( $fastwc_setting_fast_jwks_url ); ?>"
 		/>
 	<?php
 }
@@ -421,8 +421,8 @@ function fast_fast_jwks_content() {
 /**
  * Renders the onboarding URL field.
  */
-function fast_onboarding_url_content() {
-	$url = fast_get_option_or_set_default( FAST_SETTING_ONBOARDING_URL, FAST_ONBOARDING_URL );
+function fastwc_onboarding_url_content() {
+	$url = fastwc_get_option_or_set_default( FAST_SETTING_ONBOARDING_URL, FAST_ONBOARDING_URL );
 	?>
 		<input
 			name="fast_onboarding_url"
@@ -437,7 +437,7 @@ function fast_onboarding_url_content() {
 /**
  * Custom styles for Fast settings page.
  */
-function fast_admin_styles() {
+function fastwc_admin_styles() {
 	$current_screen = get_current_screen();
 
 	if ( ! empty( $current_screen ) && isset( $current_screen->id ) && 'toplevel_page_fast' !== $current_screen->id ) {
@@ -476,7 +476,7 @@ function fast_admin_styles() {
  * @param mixed  $default Default value to set option to and return if the return value of get_option is falsey.
  * @return mixed The value of the option if it is truthy, or the default if the option's value is falsey.
  */
-function fast_get_option_or_set_default( $option, $default ) {
+function fastwc_get_option_or_set_default( $option, $default ) {
 	$val = get_option( $option );
 	if ( $val ) {
 		return $val;
@@ -490,6 +490,6 @@ function fast_get_option_or_set_default( $option, $default ) {
  *
  * @return string
  */
-function fast_get_app_id() {
+function fastwc_get_app_id() {
 	return get_option( FAST_SETTING_APP_ID );
 }

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -11,35 +11,35 @@
  * Returns cart item data that Fast Checkout button can interpret.
  * This function also populates some global variables about cart state, such as whether it contains products we don't support.
  */
-function fast_get_cart_data() {
-	$fast_cart_data = array();
+function fastwc_get_cart_data() {
+	$fastwc_cart_data = array();
 
 	if ( ! empty( WC()->cart ) ) {
 		foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
 			// Populate info about this cart item.
 			// Fast backend expects strings for product/variant/quantity so we use strval() here.
-			$fast_cart_item_data = array(
+			$fastwc_cart_item_data = array(
 				'product_id' => strval( $cart_item['product_id'] ),
 				'quantity'   => strval( intval( $cart_item['quantity'] ) ), // quantity is a float in wc, casting to int first to be safer.
 			);
 			if ( ! empty( $cart_item['variation_id'] ) ) {
 				// Only track variation_id if it's set.
-				$fast_cart_item_data['variant_id'] = strval( $cart_item['variation_id'] );
+				$fastwc_cart_item_data['variant_id'] = strval( $cart_item['variation_id'] );
 			}
 			if ( ! empty( $cart_item['variation'] ) ) {
 				// Track the attribute options if they are set.
 				foreach ( $cart_item['variation'] as $option_id => $option_value ) {
-					$fast_cart_item_data['option_values'][] = array(
+					$fastwc_cart_item_data['option_values'][] = array(
 						'option_id'    => $option_id,
 						'option_value' => $option_value,
 					);
 				}
 			}
-			$fast_cart_data[ $cart_item_key ] = $fast_cart_item_data;
+			$fastwc_cart_data[ $cart_item_key ] = $fastwc_cart_item_data;
 		}
 	}
 
-	return $fast_cart_data;
+	return $fastwc_cart_data;
 }
 
 /**
@@ -51,11 +51,11 @@ function fast_get_cart_data() {
  * - The product is an external product (never supported).
  * - The FAST_SETTING_APP_ID option is empty.
  */
-function fast_should_hide_checkout_button() {
+function fastwc_should_hide_checkout_button() {
 	$return = false;
 
 	// Check for test mode and app id set.
-	if ( fast_is_hidden_for_test_mode() || fast_is_app_id_empty() ) {
+	if ( fastwc_is_hidden_for_test_mode() || fastwc_is_app_id_empty() ) {
 		$return = true;
 	}
 
@@ -64,11 +64,11 @@ function fast_should_hide_checkout_button() {
 		// - wc_product_addon_start
 		// - woocommerce_grouped_product_list_before
 		// They are ran on the PDP before this function is called.
-		global $fast_product_has_addons, $fast_product_is_grouped;
+		global $fastwc_product_has_addons, $fastwc_product_is_grouped;
 
 		if (
-			$fast_product_has_addons ||
-			$fast_product_is_grouped
+			$fastwc_product_has_addons ||
+			$fastwc_product_is_grouped
 		) {
 			$return = true;
 		}
@@ -105,13 +105,13 @@ function fast_should_hide_checkout_button() {
  * - A product in the cart is a subscription (not yet supported).
  * - The FAST_SETTING_APP_ID option is empty.
  */
-function fast_should_hide_cart_checkout_button() {
+function fastwc_should_hide_cart_checkout_button() {
 	// Check for test mode and app id set.
 	if (
-		fast_is_hidden_for_test_mode() ||
-		fast_is_app_id_empty() ||
-		fast_should_hide_because_unsupported_products() ||
-		fast_should_hide_because_too_many_coupons()
+		fastwc_is_hidden_for_test_mode() ||
+		fastwc_is_app_id_empty() ||
+		fastwc_should_hide_because_unsupported_products() ||
+		fastwc_should_hide_because_too_many_coupons()
 	) {
 		return true;
 	}
@@ -124,7 +124,7 @@ function fast_should_hide_cart_checkout_button() {
  *
  * @return bool
  */
-function fast_should_hide_because_too_many_coupons() {
+function fastwc_should_hide_because_too_many_coupons() {
 	$cart = WC()->cart;
 
 	// Check the coupon count.
@@ -141,7 +141,7 @@ function fast_should_hide_because_too_many_coupons() {
  *
  * @return bool
  */
-function fast_should_hide_because_unsupported_products() {
+function fastwc_should_hide_because_unsupported_products() {
 	$cart   = WC()->cart;
 	$return = false;
 
@@ -183,34 +183,34 @@ function fast_should_hide_because_unsupported_products() {
 /**
  * Detect if the product has any addons (Fast Checkout does not yet support these products).
  */
-function fast_wc_product_addon_start() {
+function fastwc_wc_product_addon_start() {
 	// If the store has the addons plugin installed, then this hook will run on any PDP pages for products with addons.
 	// In this situation, we want to note this so that our hook that displays the button can instead hide the button.
-	global $fast_product_has_addons;
-	$fast_product_has_addons = true;
+	global $fastwc_product_has_addons;
+	$fastwc_product_has_addons = true;
 }
-add_action( 'wc_product_addon_start', 'fast_wc_product_addon_start' );
+add_action( 'wc_product_addon_start', 'fastwc_wc_product_addon_start' );
 
 /**
  * Detect if the product is a grouped product (Fast Checkout does not yet support these products).
  */
-function fast_woocommerce_grouped_product_list_before() {
-	global $fast_product_is_grouped;
-	$fast_product_is_grouped = true;
+function fastwc_woocommerce_grouped_product_list_before() {
+	global $fastwc_product_is_grouped;
+	$fastwc_product_is_grouped = true;
 }
-add_action( 'woocommerce_grouped_product_list_before', 'fast_woocommerce_grouped_product_list_before' );
+add_action( 'woocommerce_grouped_product_list_before', 'fastwc_woocommerce_grouped_product_list_before' );
 
 /**
  * Inject Fast Checkout button after Add to Cart button.
  */
-function fast_woocommerce_after_add_to_cart_quantity() {
-	if ( fast_should_hide_checkout_button() ) {
+function fastwc_woocommerce_after_add_to_cart_quantity() {
+	if ( fastwc_should_hide_checkout_button() ) {
 		return;
 	}
 
-	fast_load_template( 'fast-pdp' );
+	fastwc_load_template( 'fast-pdp' );
 }
-add_action( 'woocommerce_after_add_to_cart_quantity', 'fast_woocommerce_after_add_to_cart_quantity' );
+add_action( 'woocommerce_after_add_to_cart_quantity', 'fastwc_woocommerce_after_add_to_cart_quantity' );
 
 /**
  * Cart page
@@ -219,38 +219,38 @@ add_action( 'woocommerce_after_add_to_cart_quantity', 'fast_woocommerce_after_ad
 /**
  * Inject Fast Checkout button after Proceed to Checkout button on cart page.
  */
-function fast_woocommerce_proceed_to_checkout() {
-	if ( fast_should_hide_cart_checkout_button() ) {
+function fastwc_woocommerce_proceed_to_checkout() {
+	if ( fastwc_should_hide_cart_checkout_button() ) {
 		return;
 	}
 
-	fast_load_template( 'fast-cart' );
+	fastwc_load_template( 'fast-cart' );
 }
-add_action( 'woocommerce_proceed_to_checkout', 'fast_woocommerce_proceed_to_checkout', 9 );
+add_action( 'woocommerce_proceed_to_checkout', 'fastwc_woocommerce_proceed_to_checkout', 9 );
 
 /**
  * Mini-cart widget
  */
-function fast_woocommerce_widget_shopping_cart_before_buttons() {
-	if ( fast_should_hide_cart_checkout_button() ) {
+function fastwc_woocommerce_widget_shopping_cart_before_buttons() {
+	if ( fastwc_should_hide_cart_checkout_button() ) {
 		return;
 	}
 
-	fast_load_template( 'fast-mini-cart' );
+	fastwc_load_template( 'fast-mini-cart' );
 }
-add_action( 'woocommerce_widget_shopping_cart_before_buttons', 'fast_woocommerce_widget_shopping_cart_before_buttons', 30 );
+add_action( 'woocommerce_widget_shopping_cart_before_buttons', 'fastwc_woocommerce_widget_shopping_cart_before_buttons', 30 );
 
 /**
  * Checkout page
  */
-function fast_woocommerce_before_checkout_form() {
-	if ( fast_should_hide_cart_checkout_button() ) {
+function fastwc_woocommerce_before_checkout_form() {
+	if ( fastwc_should_hide_cart_checkout_button() ) {
 		return;
 	}
 
-	fast_load_template( 'fast-checkout' );
+	fastwc_load_template( 'fast-checkout' );
 }
-add_action( 'woocommerce_before_checkout_form', 'fast_woocommerce_before_checkout_form' );
+add_action( 'woocommerce_before_checkout_form', 'fastwc_woocommerce_before_checkout_form' );
 
 /**
  * Handle the order object before it is inserted via the REST API.
@@ -258,7 +258,7 @@ add_action( 'woocommerce_before_checkout_form', 'fast_woocommerce_before_checkou
  * @param WC_Data         $order    Object object.
  * @param WP_REST_Request $request  Request object.
  */
-function fast_woocommerce_rest_pre_insert_shop_order_object( $order, $request ) {
+function fastwc_woocommerce_rest_pre_insert_shop_order_object( $order, $request ) {
 
 	// For order updates with a coupon line item, make sure there is a cart object.
 	if (
@@ -283,7 +283,7 @@ function fast_woocommerce_rest_pre_insert_shop_order_object( $order, $request ) 
 	// Return the order object unchanged.
 	return $order;
 }
-add_filter( 'woocommerce_rest_pre_insert_shop_order_object', 'fast_woocommerce_rest_pre_insert_shop_order_object', 10, 3 );
+add_filter( 'woocommerce_rest_pre_insert_shop_order_object', 'fastwc_woocommerce_rest_pre_insert_shop_order_object', 10, 3 );
 
 /**
  * Fast transition trash to on-hold.
@@ -291,7 +291,7 @@ add_filter( 'woocommerce_rest_pre_insert_shop_order_object', 'fast_woocommerce_r
  * @param int      $order_id The order ID.
  * @param WC_Order $order    The order object.
  */
-function fast_order_status_trash_to_on_hold( $order_id, $order ) {
+function fastwc_order_status_trash_to_on_hold( $order_id, $order ) {
 
 	if ( ! empty( $order ) ) {
 		$meta_data = $order->get_meta_data();
@@ -316,12 +316,12 @@ function fast_order_status_trash_to_on_hold( $order_id, $order ) {
 		}
 	}
 }
-add_action( 'woocommerce_order_status_trash_to_on-hold', 'fast_order_status_trash_to_on_hold', 10, 2 );
+add_action( 'woocommerce_order_status_trash_to_on-hold', 'fastwc_order_status_trash_to_on_hold', 10, 2 );
 
 /**
  * Clear the cart of `fast_order_created=1` is added to the URL.
  */
-function fast_maybe_clear_cart_and_redirect() {
+function fastwc_maybe_clear_cart_and_redirect() {
 	$fast_order_created = isset( $_GET['fast_order_created'] ) ? absint( $_GET['fast_order_created'] ) : false; // phpcs:ignore
 
 	if (
@@ -334,4 +334,4 @@ function fast_maybe_clear_cart_and_redirect() {
 		wp_safe_redirect( $cart_url );
 	}
 }
-add_action( 'init', 'fast_maybe_clear_cart_and_redirect' );
+add_action( 'init', 'fastwc_maybe_clear_cart_and_redirect' );

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -49,7 +49,7 @@ function fastwc_get_cart_data() {
  * - The product is a grouped product (not yet supported).
  * - The product is a subscription product (not yet supported).
  * - The product is an external product (never supported).
- * - The FAST_SETTING_APP_ID option is empty.
+ * - The FASTWC_SETTING_APP_ID option is empty.
  */
 function fastwc_should_hide_checkout_button() {
 	$return = false;
@@ -103,7 +103,7 @@ function fastwc_should_hide_checkout_button() {
  * - The cart has multiple coupons (not yet supported).
  * - A product in the cart has addons (not yet supported).
  * - A product in the cart is a subscription (not yet supported).
- * - The FAST_SETTING_APP_ID option is empty.
+ * - The FASTWC_SETTING_APP_ID option is empty.
  */
 function fastwc_should_hide_cart_checkout_button() {
 	// Check for test mode and app id set.

--- a/includes/js.php
+++ b/includes/js.php
@@ -8,9 +8,9 @@
 /**
  * Enqueue the Fast Woocommerce script.
  */
-function fast_enqueue_script() {
-	$fast_js = fast_get_option_or_set_default( FAST_SETTING_FAST_JS_URL, FAST_JS_URL );
-	wp_enqueue_script( 'fast-woocommerce', $fast_js, array(), '1.20.0', true );
+function fastwc_enqueue_script() {
+	$fastwc_js = fastwc_get_option_or_set_default( FAST_SETTING_FAST_JS_URL, FAST_JS_URL );
+	wp_enqueue_script( 'fast-woocommerce', $fastwc_js, array(), '1.20.0', true );
 }
-add_action( 'wp_enqueue_scripts', 'fast_enqueue_script' );
-add_action( 'login_enqueue_scripts', 'fast_enqueue_script' );
+add_action( 'wp_enqueue_scripts', 'fastwc_enqueue_script' );
+add_action( 'login_enqueue_scripts', 'fastwc_enqueue_script' );

--- a/includes/js.php
+++ b/includes/js.php
@@ -9,7 +9,7 @@
  * Enqueue the Fast Woocommerce script.
  */
 function fastwc_enqueue_script() {
-	$fastwc_js = fastwc_get_option_or_set_default( FAST_SETTING_FAST_JS_URL, FAST_JS_URL );
+	$fastwc_js = fastwc_get_option_or_set_default( FASTWC_SETTING_FAST_JS_URL, FASTWC_JS_URL );
 	wp_enqueue_script( 'fast-woocommerce', $fastwc_js, array(), '1.20.0', true );
 }
 add_action( 'wp_enqueue_scripts', 'fastwc_enqueue_script' );

--- a/includes/login.php
+++ b/includes/login.php
@@ -20,12 +20,12 @@ use \Firebase\JWT\JWK;
  * - Test mode is enabled and current user is someone who should NOT see the button when test mode is on.
  * - The FAST_SETTING_APP_ID option is empty.
  */
-function fast_should_hide_login_button() {
+function fastwc_should_hide_login_button() {
 	$return = false;
 
 	// Hide the button if the app isn't configured.
-	$fast_app_id = fast_get_app_id();
-	if ( empty( $fast_app_id ) ) {
+	$fastwc_app_id = fastwc_get_app_id();
+	if ( empty( $fastwc_app_id ) ) {
 		$return = true;
 	}
 
@@ -33,8 +33,8 @@ function fast_should_hide_login_button() {
 
 	// If test mode option is not yet set (e.g. plugin was just installed), treat it as enabled.
 	// There is code in the settings page that actually sets this to enabled the first time the user views the form.
-	$fast_test_mode = get_option( FAST_SETTING_TEST_MODE, '1' );
-	if ( ! $return && $fast_test_mode ) {
+	$fastwc_test_mode = get_option( FAST_SETTING_TEST_MODE, '1' );
+	if ( ! $return && $fastwc_test_mode ) {
 		// In test mode, show the login button if the user is an admin or their email ends with @fast.co.
 		// Otherwise, hide it.
 		$return = ! preg_match( '/@fast.co$/i', $current_user->user_email ) && ! $current_user->has_cap( 'administrator' );
@@ -52,19 +52,19 @@ function fast_should_hide_login_button() {
 /**
  * Inject Fast login component in the footer.
  */
-function fast_add_login_to_footer() {
-	if ( fast_should_hide_login_button() ) {
+function fastwc_add_login_to_footer() {
+	if ( fastwc_should_hide_login_button() ) {
 		return;
 	}
 
-	fast_load_template( 'fast-login' );
+	fastwc_load_template( 'fast-login' );
 }
-add_action( 'get_footer', 'fast_add_login_to_footer' );
+add_action( 'get_footer', 'fastwc_add_login_to_footer' );
 
 /**
  * Init Fast login.
  */
-function fast_login_init() {
+function fastwc_login_init() {
 	// If the "auth" query param isn't set, exit.
 	if ( ! isset( $_GET['auth'] ) ) {
 		return;
@@ -84,7 +84,7 @@ function fast_login_init() {
 
 	$claims = null;
 	try {
-		$claims = fast_backend_verify_jwt( $auth_token );
+		$claims = fastwc_backend_verify_jwt( $auth_token );
 	} catch ( Exception $e ) {
 		wp_die( '401 Unauthorized: Failed to login.', esc_attr( FAST_RESPONSE_401 ) );
 	}
@@ -106,7 +106,7 @@ function fast_login_init() {
 	// Get the path and query of the page being requested.
 	$request_uri = esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) );
 	$target_page = wp_parse_url( $request_uri, PHP_URL_PATH );
-	$get_query   = fast_backend_strip_auth_query_param( $_GET );
+	$get_query   = fastwc_backend_strip_auth_query_param( $_GET );
 
 	wp_set_auth_cookie( $user_to_login->ID, true );
 	wp_set_current_user( $user_to_login->ID );
@@ -121,18 +121,18 @@ function fast_login_init() {
 
 	wp_safe_redirect( 'https://' . wp_unslash( $_SERVER['HTTP_HOST'] ) . $target_page . $get_query );
 }
-add_action( 'init', 'fast_login_init' );
+add_action( 'init', 'fastwc_login_init' );
 
 /**
  * Removes the "auth" query parameter from the URL.
  *
  * @param object $get The GET request.
  */
-function fast_backend_strip_auth_query_param( $get ) {
+function fastwc_backend_strip_auth_query_param( $get ) {
 	$get_copy = $get;
 	unset( $get_copy['auth'] );
 	unset( $get_copy[ FAST_PARAM_WP_NONCE ] );
-	$get_query = fast_backend_join_get_parameters( $get_copy );
+	$get_query = fastwc_backend_join_get_parameters( $get_copy );
 	if ( strlen( $get_query ) > 0 ) {
 		$get_query = '?' . $get_query;
 	}
@@ -144,7 +144,7 @@ function fast_backend_strip_auth_query_param( $get ) {
  *
  * @param object $parameters A copy of the GET request.
  */
-function fast_backend_join_get_parameters( $parameters ) {
+function fastwc_backend_join_get_parameters( $parameters ) {
 	$keys        = array_keys( $parameters );
 	$assignments = array();
 	foreach ( $keys as $key ) {
@@ -159,7 +159,7 @@ function fast_backend_join_get_parameters( $parameters ) {
  * @param string $token_str The stringified token from the auth query param.
  * @throws UnexpectedValueException Thrown when JWT audience doesn't match this app's ID.
  */
-function fast_backend_verify_jwt( $token_str ) {
+function fastwc_backend_verify_jwt( $token_str ) {
 	$res     = wp_remote_get( get_option( FAST_SETTING_FAST_JWKS_URL ) );
 	$jwks    = wp_remote_retrieve_body( $res );
 	$keys    = json_decode( $jwks, true );
@@ -167,7 +167,7 @@ function fast_backend_verify_jwt( $token_str ) {
 
 	$claims = JWT::decode( $token_str, $key_set, array( 'RS256' ) );
 
-	$app_id = fast_get_app_id();
+	$app_id = fastwc_get_app_id();
 	if ( $app_id !== $claims->aud ) {
 		throw new UnexpectedValueException( 'Audience mismatch' );
 	}

--- a/includes/routes.php
+++ b/includes/routes.php
@@ -6,14 +6,14 @@
  */
 
 // Define the API route base path.
-define( 'FAST_ROUTES_BASE', 'wc/fast/v1' );
+define( 'FASTWC_ROUTES_BASE', 'wc/fast/v1' );
 
 // Provides an API for polling shipping options.
-require_once FAST_PATH . 'includes/routes/shipping.php';
+require_once FASTWC_PATH . 'includes/routes/shipping.php';
 // Provides an API that exposes shipping zones.
-require_once FAST_PATH . 'includes/routes/shipping-zones.php';
+require_once FASTWC_PATH . 'includes/routes/shipping-zones.php';
 // Provides an API that exposes plugin info.
-require_once FAST_PATH . 'includes/routes/plugin-info.php';
+require_once FASTWC_PATH . 'includes/routes/plugin-info.php';
 
 /**
  * Register Fast Woocommerce routes for the REST API.
@@ -21,7 +21,7 @@ require_once FAST_PATH . 'includes/routes/plugin-info.php';
 function fastwc_rest_api_init() {
 	// Register a utility route to get information on installed plugins.
 	register_rest_route(
-		FAST_ROUTES_BASE . '/store',
+		FASTWC_ROUTES_BASE . '/store',
 		'plugins',
 		array(
 			'methods'             => 'GET',
@@ -32,7 +32,7 @@ function fastwc_rest_api_init() {
 
 	// Register a route to collect all possible shipping locations.
 	register_rest_route(
-		FAST_ROUTES_BASE,
+		FASTWC_ROUTES_BASE,
 		'shipping_zones',
 		array(
 			'methods'             => 'GET',
@@ -44,7 +44,7 @@ function fastwc_rest_api_init() {
 	// Register a route to calculate available shipping rates.
 	// FE -> OMS -> Blender -> (pID, variantID, Shipping info, CustomerID)Plugin.
 	register_rest_route(
-		FAST_ROUTES_BASE,
+		FASTWC_ROUTES_BASE,
 		'shipping',
 		array(
 			'methods'             => 'POST',
@@ -55,7 +55,7 @@ function fastwc_rest_api_init() {
 
 	// Register a route to test the Authorization header.
 	register_rest_route(
-		FAST_ROUTES_BASE,
+		FASTWC_ROUTES_BASE,
 		'authecho',
 		array(
 			'methods'             => 'GET',

--- a/includes/routes.php
+++ b/includes/routes.php
@@ -18,15 +18,15 @@ require_once FAST_PATH . 'includes/routes/plugin-info.php';
 /**
  * Register Fast Woocommerce routes for the REST API.
  */
-function fast_rest_api_init() {
+function fastwc_rest_api_init() {
 	// Register a utility route to get information on installed plugins.
 	register_rest_route(
 		FAST_ROUTES_BASE . '/store',
 		'plugins',
 		array(
 			'methods'             => 'GET',
-			'callback'            => 'fast_get_plugin_info',
-			'permission_callback' => 'fast_api_permission_callback',
+			'callback'            => 'fastwc_get_plugin_info',
+			'permission_callback' => 'fastwc_api_permission_callback',
 		)
 	);
 
@@ -36,8 +36,8 @@ function fast_rest_api_init() {
 		'shipping_zones',
 		array(
 			'methods'             => 'GET',
-			'callback'            => 'fast_get_zones',
-			'permission_callback' => 'fast_api_permission_callback',
+			'callback'            => 'fastwc_get_zones',
+			'permission_callback' => 'fastwc_api_permission_callback',
 		)
 	);
 
@@ -48,8 +48,8 @@ function fast_rest_api_init() {
 		'shipping',
 		array(
 			'methods'             => 'POST',
-			'callback'            => 'fast_calculate_shipping',
-			'permission_callback' => 'fast_api_permission_callback',
+			'callback'            => 'fastwc_calculate_shipping',
+			'permission_callback' => 'fastwc_api_permission_callback',
 		)
 	);
 
@@ -59,19 +59,19 @@ function fast_rest_api_init() {
 		'authecho',
 		array(
 			'methods'             => 'GET',
-			'callback'            => 'fast_test_authorization_header',
+			'callback'            => 'fastwc_test_authorization_header',
 			'permission_callback' => '__return_true',
 		)
 	);
 }
-add_action( 'rest_api_init', 'fast_rest_api_init' );
+add_action( 'rest_api_init', 'fastwc_rest_api_init' );
 
 /**
  * REST API permissions callback.
  *
  * @return bool
  */
-function fast_api_permission_callback() {
+function fastwc_api_permission_callback() {
 	// Make sure an instance of WooCommerce is loaded.
 	// This will load the `WC_REST_Authentication` class, which
 	// handles the API consumer key and secret.
@@ -87,7 +87,7 @@ function fast_api_permission_callback() {
  *
  * @return array|WP_Error|WP_REST_Response
  */
-function fast_test_authorization_header( $request ) {
+function fastwc_test_authorization_header( $request ) {
 	$auth_header = 'No Authorization Header';
 
 	$headers = $request->get_headers();

--- a/includes/routes/plugin-info.php
+++ b/includes/routes/plugin-info.php
@@ -31,7 +31,7 @@
  *     }
  * }
  */
-function fast_get_plugin_info() {
+function fastwc_get_plugin_info() {
 
 	// Get all plugins.
 	include_once 'wp-admin/includes/plugin.php';

--- a/includes/routes/shipping-zones.php
+++ b/includes/routes/shipping-zones.php
@@ -11,7 +11,7 @@
  *
  * @return array|WP_Error|WP_REST_Response
  */
-function fast_get_zones() {
+function fastwc_get_zones() {
 	$zone_ids = array_keys( array( '' ) + WC_Shipping_Zones::get_zones() );
 	$loc_arr  = array();
 
@@ -25,7 +25,7 @@ function fast_get_zones() {
 
 		$loc_arr = array_merge(
 			$loc_arr,
-			fast_parse_locations( $locations, $loc_arr )
+			fastwc_parse_locations( $locations, $loc_arr )
 		);
 	}
 
@@ -40,7 +40,7 @@ function fast_get_zones() {
  *
  * @return array
  */
-function fast_parse_locations( $locations, $loc_arr ) {
+function fastwc_parse_locations( $locations, $loc_arr ) {
 	$new_loc_arr = array();
 
 	foreach ( $locations as $location ) {
@@ -49,7 +49,7 @@ function fast_parse_locations( $locations, $loc_arr ) {
 		}
 
 		// Do not insert item with same code.
-		if ( ! fast_loc_arr_has_location( $loc_arr, $location ) ) {
+		if ( ! fastwc_loc_arr_has_location( $loc_arr, $location ) ) {
 			$new_loc_arr[] = array(
 				'code' => $location->code,
 				'type' => $location->type,
@@ -68,7 +68,7 @@ function fast_parse_locations( $locations, $loc_arr ) {
  *
  * @return bool
  */
-function fast_loc_arr_has_location( $loc_arr, $location ) {
+function fastwc_loc_arr_has_location( $loc_arr, $location ) {
 	foreach ( $loc_arr as $li ) {
 		if ( $li->code === $location->code ) {
 			return true;

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -13,25 +13,25 @@
  * @uses add_shortcode
  * @see https://codex.wordpress.org/Shortcode_API
  */
-function fast_add_shortcodes() {
+function fastwc_add_shortcodes() {
 	// Add PDP checkout button shortcode.
-	add_shortcode( 'fast_product', 'fast_shortcode_product_button' );
+	add_shortcode( 'fast_product', 'fastwc_shortcode_product_button' );
 
 	// Add cart checktout button shortcode.
-	add_shortcode( 'fast_cart', 'fast_shortcode_cart_button' );
+	add_shortcode( 'fast_cart', 'fastwc_shortcode_cart_button' );
 }
-add_action( 'init', 'fast_add_shortcodes' );
+add_action( 'init', 'fastwc_add_shortcodes' );
 
 /**
- * Display the Fast PDP button from the `fast_product` shortcode.
+ * Display the Fast PDP button from the `fastwc_product` shortcode.
  * Note: This is currently exprimental and should not be used in a production site.
  *
  * @param array $atts Shortcode attributes.
  *
  * @return string
  */
-function fast_shortcode_product_button( $atts ) {
-	return fast_shortcode_button_template(
+function fastwc_shortcode_product_button( $atts ) {
+	return fastwc_shortcode_button_template(
 		'buttons/fast-checkout-button',
 		$atts
 	);
@@ -44,8 +44,8 @@ function fast_shortcode_product_button( $atts ) {
  *
  * @return string
  */
-function fast_shortcode_cart_button( $atts ) {
-	return fast_shortcode_button_template(
+function fastwc_shortcode_cart_button( $atts ) {
+	return fastwc_shortcode_button_template(
 		'buttons/fast-checkout-cart-button',
 		$atts
 	);
@@ -59,13 +59,13 @@ function fast_shortcode_cart_button( $atts ) {
  *
  * @return string
  */
-function fast_shortcode_button_template( $template, $atts ) {
+function fastwc_shortcode_button_template( $template, $atts ) {
 
 	// Start the output buffer.
 	ob_start();
 
 	// Load the button template, passing in `$atts` as the template's `$args`.
-	fast_load_template( $template, $atts );
+	fastwc_load_template( $template, $atts );
 
 	return ob_get_clean();
 }

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -22,7 +22,7 @@ function fastwc_load_template( $template_name, $args = array() ) {
 		get_template_directory() . '/templates/' . $template_name . '.php',
 
 		// Plugin directory.
-		FAST_PATH . 'templates/' . $template_name . '.php',
+		FASTWC_PATH . 'templates/' . $template_name . '.php',
 	);
 
 	// Check each file location and load the first one that exists.
@@ -51,7 +51,7 @@ function fastwc_load_template( $template_name, $args = array() ) {
 function fastwc_is_hidden_for_test_mode() {
 	// If test mode option is not yet set (e.g. plugin was just installed), treat it as enabled.
 	// There is code in the settings page that actually sets this to enabled the first time the user views the form.
-	$fastwc_test_mode = get_option( FAST_SETTING_TEST_MODE, '1' );
+	$fastwc_test_mode = get_option( FASTWC_SETTING_TEST_MODE, '1' );
 	if ( $fastwc_test_mode ) {
 		// In test mode, we only want to show the button if the user is an admin or their email ends with @fast.co.
 		$current_user = wp_get_current_user();

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -13,7 +13,7 @@
  *
  * @uses load_template
  */
-function fast_load_template( $template_name, $args = array() ) {
+function fastwc_load_template( $template_name, $args = array() ) {
 	$locations = array(
 		// Child theme directory.
 		get_stylesheet_directory() . '/templates/' . $template_name . '.php',
@@ -48,11 +48,11 @@ function fast_load_template( $template_name, $args = array() ) {
  *
  * @return bool true if we should hide the button, false otherwise
  */
-function fast_is_hidden_for_test_mode() {
+function fastwc_is_hidden_for_test_mode() {
 	// If test mode option is not yet set (e.g. plugin was just installed), treat it as enabled.
 	// There is code in the settings page that actually sets this to enabled the first time the user views the form.
-	$fast_test_mode = get_option( FAST_SETTING_TEST_MODE, '1' );
-	if ( $fast_test_mode ) {
+	$fastwc_test_mode = get_option( FAST_SETTING_TEST_MODE, '1' );
+	if ( $fastwc_test_mode ) {
 		// In test mode, we only want to show the button if the user is an admin or their email ends with @fast.co.
 		$current_user = wp_get_current_user();
 		if ( ! preg_match( '/@fast.co$/i', $current_user->user_email ) && ! $current_user->has_cap( 'administrator' ) ) {
@@ -69,7 +69,7 @@ function fast_is_hidden_for_test_mode() {
  *
  * @return bool true if the app ID is empty, false otherwise
  */
-function fast_is_app_id_empty() {
-	$fast_app_id = fast_get_app_id();
-	return empty( $fast_app_id );
+function fastwc_is_app_id_empty() {
+	$fastwc_app_id = fastwc_get_app_id();
+	return empty( $fastwc_app_id );
 }

--- a/templates/buttons/fast-checkout-button.php
+++ b/templates/buttons/fast-checkout-button.php
@@ -5,6 +5,6 @@
  * @package Fast
  */
 
-$fast_app_id = fast_get_app_id();
+$fastwc_app_id = fastwc_get_app_id();
 ?>
-	<fast-checkout-button app_id="<?php echo esc_attr( $fast_app_id ); ?>"></fast-checkout-button>
+	<fast-checkout-button app_id="<?php echo esc_attr( $fastwc_app_id ); ?>"></fast-checkout-button>

--- a/templates/buttons/fast-checkout-cart-button.php
+++ b/templates/buttons/fast-checkout-cart-button.php
@@ -5,14 +5,14 @@
  * @package Fast
  */
 
-$fast_app_id           = fast_get_app_id();
-$fast_cart_data        = fast_get_cart_data();
-$cart_data             = wp_json_encode( array_values( $fast_cart_data ) );
+$fastwc_app_id         = fastwc_get_app_id();
+$fastwc_cart_data      = fastwc_get_cart_data();
+$cart_data             = wp_json_encode( array_values( $fastwc_cart_data ) );
 $applied_coupons       = ! empty( WC()->cart ) ? WC()->cart->get_applied_coupons() : array();
 $applied_coupons_count = count( $applied_coupons );
 ?>
 	<fast-checkout-cart-button
-		app_id="<?php echo esc_attr( $fast_app_id ); ?>"
+		app_id="<?php echo esc_attr( $fastwc_app_id ); ?>"
 		cart_data="<?php echo esc_attr( $cart_data ); ?>"
 		<?php
 		if ( 1 === $applied_coupons_count ) {

--- a/templates/fast-cart.php
+++ b/templates/fast-cart.php
@@ -5,13 +5,13 @@
  * @package Fast
  */
 
-$fast_cart_button_styles = fast_get_option_or_set_default( FAST_SETTING_CART_BUTTON_STYLES, FAST_SETTING_CART_BUTTON_STYLES_DEFAULT );
+$fastwc_cart_button_styles = fastwc_get_option_or_set_default( FASTWC_SETTING_CART_BUTTON_STYLES, FASTWC_SETTING_CART_BUTTON_STYLES_DEFAULT );
 ?>
 
 		<div class="fast-cart-wrapper">
-			<?php fast_load_template( 'buttons/fast-checkout-cart-button' ); ?>
+			<?php fastwc_load_template( 'buttons/fast-checkout-cart-button' ); ?>
 			<div class="fast-cart-or"><?php esc_html_e( 'OR', 'fast' ); ?></div>
 		</div>
 		<style>
-			<?php echo esc_html( $fast_cart_button_styles ); ?>
+			<?php echo esc_html( $fastwc_cart_button_styles ); ?>
 		</style>

--- a/templates/fast-checkout.php
+++ b/templates/fast-checkout.php
@@ -5,13 +5,13 @@
  * @package Fast
  */
 
-$fast_checkout_button_styles = fast_get_option_or_set_default( FAST_SETTING_CHECKOUT_BUTTON_STYLES, FAST_SETTING_CHECKOUT_BUTTON_STYLES_DEFAULT );
+$fastwc_checkout_button_styles = fastwc_get_option_or_set_default( FASTWC_SETTING_CHECKOUT_BUTTON_STYLES, FASTWC_SETTING_CHECKOUT_BUTTON_STYLES_DEFAULT );
 ?>
 
 		<div class="fast-checkout-wrapper">
-			<?php fast_load_template( 'buttons/fast-checkout-cart-button' ); ?>
+			<?php fastwc_load_template( 'buttons/fast-checkout-cart-button' ); ?>
 			<div class="fast-checkout-or"><?php esc_html_e( 'OR', 'fast' ); ?></div>
 		</div>
 		<style>
-			<?php echo esc_html( $fast_checkout_button_styles ); ?>
+			<?php echo esc_html( $fastwc_checkout_button_styles ); ?>
 		</style>

--- a/templates/fast-login.php
+++ b/templates/fast-login.php
@@ -5,16 +5,16 @@
  * @package Fast
  */
 
-$fast_app_id              = fast_get_app_id();
-$fast_login_button_styles = fast_get_option_or_set_default( FAST_SETTING_LOGIN_BUTTON_STYLES, FAST_SETTING_LOGIN_BUTTON_STYLES_DEFAULT );
-$nonce                    = wp_create_nonce( 'fast-backend-login-auth' );
+$fastwc_app_id              = fastwc_get_app_id();
+$fastwc_login_button_styles = fastwc_get_option_or_set_default( FASTWC_SETTING_LOGIN_BUTTON_STYLES, FASTWC_SETTING_LOGIN_BUTTON_STYLES_DEFAULT );
+$nonce                      = wp_create_nonce( 'fast-backend-login-auth' );
 ?>
 
 		<div class="fast-login-wrapper">
-			<fast-login id="fastloginbutton" app_id="<?php echo esc_attr( $fast_app_id ); ?>" data-nonce="<?php echo esc_attr( $nonce ); ?>"></fast-login>
+			<fast-login id="fastloginbutton" app_id="<?php echo esc_attr( $fastwc_app_id ); ?>" data-nonce="<?php echo esc_attr( $nonce ); ?>"></fast-login>
 		</div>
 		<style>
-			<?php echo esc_html( $fast_login_button_styles ); ?>
+			<?php echo esc_html( $fastwc_login_button_styles ); ?>
 		</style>
 		<script type="text/javascript">
 			document

--- a/templates/fast-mini-cart.php
+++ b/templates/fast-mini-cart.php
@@ -5,13 +5,13 @@
  * @package Fast
  */
 
-$fast_mini_cart_button_styles = fast_get_option_or_set_default( FAST_SETTING_MINI_CART_BUTTON_STYLES, FAST_SETTING_MINI_CART_BUTTON_STYLES_DEFAULT );
+$fastwc_mini_cart_button_styles = fastwc_get_option_or_set_default( FASTWC_SETTING_MINI_CART_BUTTON_STYLES, FASTWC_SETTING_MINI_CART_BUTTON_STYLES_DEFAULT );
 ?>
 
 		<div class="fast-mini-cart-wrapper">
-			<?php fast_load_template( 'buttons/fast-checkout-cart-button' ); ?>
+			<?php fastwc_load_template( 'buttons/fast-checkout-cart-button' ); ?>
 			<div class="fast-mini-cart-or"><?php esc_html_e( 'OR', 'fast' ); ?></div>
 		</div>
 		<style>
-			<?php echo esc_html( $fast_mini_cart_button_styles ); ?>
+			<?php echo esc_html( $fastwc_mini_cart_button_styles ); ?>
 		</style>

--- a/templates/fast-pdp.php
+++ b/templates/fast-pdp.php
@@ -5,13 +5,13 @@
  * @package Fast
  */
 
-$fast_pdp_button_styles = fast_get_option_or_set_default( FAST_SETTING_PDP_BUTTON_STYLES, FAST_SETTING_PDP_BUTTON_STYLES_DEFAULT );
+$fastwc_pdp_button_styles = fastwc_get_option_or_set_default( FASTWC_SETTING_PDP_BUTTON_STYLES, FASTWC_SETTING_PDP_BUTTON_STYLES_DEFAULT );
 ?>
 
 		<div class="fast-pdp-wrapper">
-			<?php fast_load_template( 'buttons/fast-checkout-button' ); ?>
+			<?php fastwc_load_template( 'buttons/fast-checkout-button' ); ?>
 			<div class="fast-pdp-or"><?php esc_html_e( 'OR', 'fast' ); ?></div>
 		</div>
 		<style>
-				<?php echo esc_html( $fast_pdp_button_styles ); ?>
+				<?php echo esc_html( $fastwc_pdp_button_styles ); ?>
 		</style>


### PR DESCRIPTION
# Description

Update function and constant prefixes to be more specific to the plugin. This is due to the feedback from the WordPress Plugin Directory review:

# Testing instructions

1. Install the update.
2. Verify that everything continues to work as it did before.

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`