### PR TITLE
Shipping Options endpoint clear cart before filling

### DIFF
--- a/includes/routes/shipping.php
+++ b/includes/routes/shipping.php
@@ -70,6 +70,9 @@ function fastwc_shipping_init_wc_cart() {
 		// refreshed on wp_loaded, which has already happened
 		// by this point).
 		WC()->cart->get_cart();
+
+		// This cart may contain items from prev session empty before using
+		WC()->cart->empty_cart();
 	}
 }
 


### PR DESCRIPTION
# Description
We have seen that some older items may apeear in the cart init phase and merging those with new items may result in unwanted shipping options / option prices. This PR clears the cart before the items in the requests are added into it.
This behavior was 100% reproducable from the backend whereas using postman we were not able to reproduce so I suspect it might be related to session being persisted somehow.


# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`