### PR TITLE
Update WP tested version to 5.7

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: fastaf, tessak22, corywebb
 Tags: fast, fast checkout, checkout, woocommerce, woocommerce payment, woocommerce checkout, quick checkout, 1 click checkout, one click checkout
 Requires at least: 5.1
-Tested up to: 5.2
+Tested up to: 5.7
 Requires PHP: 7.2
 Stable tag: 1.0
 License: GPLv2 or later


### PR DESCRIPTION
# Description

Update the latest version of WordPress with which this plugin has been tested to 5.7, since this plugin is regularly tested with WordPress 5.7.

# Testing instructions

Nothing to test. This is just an update to the `readme.txt` file.

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`