### PR TITLE
PINT-387 Fix incorrect function name

### DIFF
--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -31,7 +31,7 @@ add_action( 'init', 'fastwc_add_shortcodes' );
  * @return string
  */
 function fastwc_shortcode_product_button( $atts ) {
-	$atts = wp_shortcode_atts(
+	$atts = shortcode_atts(
 		array(
 			'product_id' => 0,
 		),


### PR DESCRIPTION
# Description

This replaces `wp_shortcode_atts` with `shortcode_atts` because `wp_shortcode_atts` does not exist.

# Testing instructions

Verify that there are no errors on this page: https://fasttestdev.wpcomstaging.com/fast-shortcodes/

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`

@brikr @ilkerulutas this is ready for review.