### PR TITLE
PINT-403 Add debug mode

### DIFF
--- a/fast.php
+++ b/fast.php
@@ -13,6 +13,8 @@
 define( 'FASTWC_PATH', plugin_dir_path( __FILE__ ) );
 define( 'FASTWC_URL', plugin_dir_url( __FILE__ ) );
 
+// Fast debug functions.
+require_once FASTWC_PATH . 'includes/debug.php';
 // WP Admin plugin settings.
 require_once FASTWC_PATH . 'includes/admin/settings.php';
 // Loads Fast js and css assets.

--- a/includes/admin/constants.php
+++ b/includes/admin/constants.php
@@ -11,6 +11,8 @@ define( 'FASTWC_SETTING_TEST_MODE_NOT_SET', 'fast test mode not set' );
 define( 'FASTWC_SETTING_FAST_JS_URL', 'fast_fast_js_url' );
 define( 'FASTWC_SETTING_FAST_JWKS_URL', 'fast_fast_jwks_url' );
 define( 'FASTWC_SETTING_ONBOARDING_URL', 'fast_onboarding_url' );
+define( 'FASTWC_SETTING_DEBUG_MODE', 'fastwc_debug_mode' );
+define( 'FASTWC_SETTING_DEBUG_MODE_NOT_SET', 'fast debug mode not set' );
 define( 'FASTWC_SETTING_PDP_BUTTON_STYLES', 'fast_pdp_button_styles' );
 define( 'FASTWC_SETTING_CART_BUTTON_STYLES', 'fast_cart_button_styles' );
 define( 'FASTWC_SETTING_MINI_CART_BUTTON_STYLES', 'fast_mini_cart_button_styles' );

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -43,6 +43,7 @@ function fastwc_admin_create_menu() {
 	register_setting( 'fast', FASTWC_SETTING_FAST_JS_URL );
 	register_setting( 'fast', FASTWC_SETTING_FAST_JWKS_URL );
 	register_setting( 'fast', FASTWC_SETTING_ONBOARDING_URL );
+	register_setting( 'fast', FASTWC_SETTING_DEBUG_MODE );
 
 	// Check whether the woocommerce plugin is active.
 	$active_plugins = apply_filters( 'active_plugins', get_option( 'active_plugins' ) );
@@ -119,6 +120,7 @@ function fastwc_admin_setup_fields() {
 	// Test Mode settings.
 	$settings_section = 'fast_test_mode';
 	add_settings_field( FASTWC_SETTING_TEST_MODE, __( 'Test Mode', 'fast' ), 'fastwc_test_mode_content', $settings_page, $settings_section );
+	add_settings_field( FASTWC_SETTING_DEBUG_MODE, __( 'Debug Mode', 'fast' ), 'fastwc_debug_mode_content', $settings_page, $settings_section );
 	add_settings_field( FASTWC_SETTING_DISABLE_MULTICURRENCY, __( 'Disable Multicurrency Support', 'fast' ), 'fastwc_disable_multicurrency_content', $settings_page, $settings_section );
 
 	// Advanced settings.
@@ -267,6 +269,29 @@ function fastwc_test_mode_content() {
 			'current'     => $fastwc_test_mode,
 			'label'       => __( 'Enable test mode', 'fast' ),
 			'description' => __( 'When test mode is enabled, only logged-in admin users will see the Fast Checkout button.', 'fast' ),
+		)
+	);
+}
+
+/**
+ * Renders the Debug Mode field.
+ */
+function fastwc_debug_mode_content() {
+	$fastwc_debug_mode = get_option( FASTWC_SETTING_DEBUG_MODE, FASTWC_SETTING_DEBUG_MODE_NOT_SET );
+
+	if ( FASTWC_SETTING_DEBUG_MODE_NOT_SET === $fastwc_debug_mode ) {
+		// If the option is FASTWC_SETTING_DEBUG_MODE_NOT_SET, then it hasn't yet been set. In this case, we
+		// want to configure debug mode to be off.
+		$fastwc_debug_mode = 0;
+		update_option( FASTWC_SETTING_DEBUG_MODE, $fastwc_debug_mode );
+	}
+
+	fastwc_settings_field_checkbox(
+		array(
+			'name'        => FASTWC_SETTING_DEBUG_MODE,
+			'current'     => $fastwc_debug_mode,
+			'label'       => __( 'Enable debug mode', 'fast' ),
+			'description' => __( 'When debug mode is enabled, the Fast plugin will maintain an error log.', 'fast' ),
 		)
 	);
 }

--- a/includes/debug.php
+++ b/includes/debug.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Fast Debug Mode to add message to WC_Logger
+ *
+ * @package Fast
+ */
+
+/**
+ * Check if Fast debug mode is enabled.
+ *
+ * @return bool
+ */
+function fastwc_debug_mode_enabled() {
+	$fastwc_debug_mode = get_option( FASTWC_SETTING_DEBUG_MODE, 0 );
+
+	return ! empty( $fastwc_debug_mode );
+}
+
+/**
+ * Log a message if Fast debug mode is enabled.
+ *
+ * @param string $level   WooCommerce log level. One of the following:
+ *     'emergency': System is unusable.
+ *     'alert': Action must be taken immediately.
+ *     'critical': Critical conditions.
+ *     'error': Error conditions.
+ *     'warning': Warning conditions.
+ *     'notice': Normal but significant condition.
+ *     'info': Informational messages.
+ *     'debug': Debug-level messages.
+ * @param string $message Message to log.
+ */
+function fastwc_log( $level, $message ) {
+	if ( ! fastwc_debug_mode_enabled() ) {
+		return;
+	}
+
+	$logger = wc_get_logger();
+	$logger->log( $level, $message, array( 'source' => 'fastwc' ) );
+}
+
+/**
+ * Adds an emergency level message if Fast debug mode is enabled
+ *
+ * System is unusable.
+ *
+ * @see WC_Logger::log
+ *
+ * @param string $message Message to log.
+ */
+function fastwc_emergency( $message ) {
+	fastwc_log( WC_Log_Levels::EMERGENCY, $message );
+}
+
+/**
+ * Adds an alert level message if Fast debug mode is enabled.
+ *
+ * Action must be taken immediately.
+ * Example: Entire website down, database unavailable, etc.
+ *
+ * @see WC_Logger::log
+ *
+ * @param string $message Message to log.
+ */
+function fastwc_alert( $message ) {
+	fastwc_log( WC_Log_Levels::ALERT, $message );
+}
+
+/**
+ * Adds a critical level message if Fast debug mode is enabled.
+ *
+ * Critical conditions.
+ * Example: Application component unavailable, unexpected exception.
+ *
+ * @see WC_Logger::log
+ *
+ * @param string $message Message to log.
+ */
+function fastwc_critical( $message ) {
+	fastwc_log( WC_Log_Levels::CRITICAL, $message );
+}
+
+/**
+ * Adds an error level message if Fast debug mode is enabled.
+ *
+ * Runtime errors that do not require immediate action but should typically be logged
+ * and monitored.
+ *
+ * @see WC_Logger::log
+ *
+ * @param string $message Message to log.
+ */
+function fastwc_error( $message ) {
+	fastwc_log( WC_Log_Levels::ERROR, $message );
+}
+
+/**
+ * Adds a warning level message if Fast debug mode is enabled.
+ *
+ * Exceptional occurrences that are not errors.
+ *
+ * Example: Use of deprecated APIs, poor use of an API, undesirable things that are not
+ * necessarily wrong.
+ *
+ * @see WC_Logger::log
+ *
+ * @param string $message Message to log.
+ */
+function fastwc_warning( $message ) {
+	fastwc_log( WC_Log_Levels::WARNING, $message );
+}
+
+/**
+ * Adds a notice level message if Fast debug mode is enabled.
+ *
+ * Normal but significant events.
+ *
+ * @see WC_Logger::log
+ *
+ * @param string $message Message to log.
+ */
+function fastwc_notice( $message ) {
+	fastwc_log( WC_Log_Levels::NOTICE, $message );
+}
+
+/**
+ * Adds a info level message if Fast debug mode is enabled.
+ *
+ * Interesting events.
+ * Example: User logs in, SQL logs.
+ *
+ * @see WC_Logger::log
+ *
+ * @param string $message Message to log.
+ */
+function fastwc_info( $message ) {
+	fastwc_log( WC_Log_Levels::INFO, $message );
+}
+
+/**
+ * Adds a debug level message if Fast debug mode is enabled.
+ *
+ * Detailed debug information.
+ *
+ * @see WC_Logger::log
+ *
+ * @param string $message Message to log.
+ */
+function fastwc_debug( $message ) {
+	fastwc_log( WC_Log_Levels::DEBUG, $message );
+}

--- a/includes/debug.php
+++ b/includes/debug.php
@@ -20,14 +20,14 @@ function fastwc_debug_mode_enabled() {
  * Log a message if Fast debug mode is enabled.
  *
  * @param string $level   WooCommerce log level. One of the following:
- *     'emergency': System is unusable.
- *     'alert': Action must be taken immediately.
- *     'critical': Critical conditions.
- *     'error': Error conditions.
- *     'warning': Warning conditions.
- *     'notice': Normal but significant condition.
- *     'info': Informational messages.
- *     'debug': Debug-level messages.
+ *                          'emergency': System is unusable.
+ *                          'alert': Action must be taken immediately.
+ *                          'critical': Critical conditions.
+ *                          'error': Error conditions.
+ *                          'warning': Warning conditions.
+ *                          'notice': Normal but significant condition.
+ *                          'info': Informational messages.
+ *                          'debug': Debug-level messages.
  * @param string $message Message to log.
  */
 function fastwc_log( $level, $message ) {

--- a/includes/debug.php
+++ b/includes/debug.php
@@ -46,7 +46,7 @@ function fastwc_log( $level, $message ) {
  *
  * @param string $message Message to log.
  */
-function fastwc_emergency( $message ) {
+function fastwc_log_emergency( $message ) {
 	fastwc_log( WC_Log_Levels::EMERGENCY, $message );
 }
 
@@ -60,7 +60,7 @@ function fastwc_emergency( $message ) {
  *
  * @param string $message Message to log.
  */
-function fastwc_alert( $message ) {
+function fastwc_log_alert( $message ) {
 	fastwc_log( WC_Log_Levels::ALERT, $message );
 }
 
@@ -74,7 +74,7 @@ function fastwc_alert( $message ) {
  *
  * @param string $message Message to log.
  */
-function fastwc_critical( $message ) {
+function fastwc_log_critical( $message ) {
 	fastwc_log( WC_Log_Levels::CRITICAL, $message );
 }
 
@@ -88,7 +88,7 @@ function fastwc_critical( $message ) {
  *
  * @param string $message Message to log.
  */
-function fastwc_error( $message ) {
+function fastwc_log_error( $message ) {
 	fastwc_log( WC_Log_Levels::ERROR, $message );
 }
 
@@ -104,7 +104,7 @@ function fastwc_error( $message ) {
  *
  * @param string $message Message to log.
  */
-function fastwc_warning( $message ) {
+function fastwc_log_warning( $message ) {
 	fastwc_log( WC_Log_Levels::WARNING, $message );
 }
 
@@ -117,7 +117,7 @@ function fastwc_warning( $message ) {
  *
  * @param string $message Message to log.
  */
-function fastwc_notice( $message ) {
+function fastwc_log_notice( $message ) {
 	fastwc_log( WC_Log_Levels::NOTICE, $message );
 }
 
@@ -131,7 +131,7 @@ function fastwc_notice( $message ) {
  *
  * @param string $message Message to log.
  */
-function fastwc_info( $message ) {
+function fastwc_log_info( $message ) {
 	fastwc_log( WC_Log_Levels::INFO, $message );
 }
 
@@ -144,6 +144,6 @@ function fastwc_info( $message ) {
  *
  * @param string $message Message to log.
  */
-function fastwc_debug( $message ) {
+function fastwc_log_debug( $message ) {
 	fastwc_log( WC_Log_Levels::DEBUG, $message );
 }

--- a/includes/debug.php
+++ b/includes/debug.php
@@ -31,12 +31,10 @@ function fastwc_debug_mode_enabled() {
  * @param string $message Message to log.
  */
 function fastwc_log( $level, $message ) {
-	if ( ! fastwc_debug_mode_enabled() ) {
-		return;
+	if ( fastwc_debug_mode_enabled() ) {
+		$logger = wc_get_logger();
+		$logger->log( $level, $message, array( 'source' => 'fastwc' ) );
 	}
-
-	$logger = wc_get_logger();
-	$logger->log( $level, $message, array( 'source' => 'fastwc' ) );
 }
 
 /**

--- a/includes/routes.php
+++ b/includes/routes.php
@@ -30,6 +30,8 @@ function fastwc_rest_api_init() {
 		)
 	);
 
+	fastwc_log_info( 'Registered route: ' . FASTWC_ROUTES_BASE . '/store/plugins' );
+
 	// Register a route to collect all possible shipping locations.
 	register_rest_route(
 		FASTWC_ROUTES_BASE,
@@ -40,6 +42,8 @@ function fastwc_rest_api_init() {
 			'permission_callback' => 'fastwc_api_permission_callback',
 		)
 	);
+
+	fastwc_log_info( 'Registered route: ' . FASTWC_ROUTES_BASE . '/shipping_zones' );
 
 	// Register a route to calculate available shipping rates.
 	// FE -> OMS -> Blender -> (pID, variantID, Shipping info, CustomerID)Plugin.
@@ -53,6 +57,8 @@ function fastwc_rest_api_init() {
 		)
 	);
 
+	fastwc_log_info( 'Registered route: ' . FASTWC_ROUTES_BASE . '/shipping' );
+
 	// Register a route to test the Authorization header.
 	register_rest_route(
 		FASTWC_ROUTES_BASE,
@@ -63,6 +69,8 @@ function fastwc_rest_api_init() {
 			'permission_callback' => '__return_true',
 		)
 	);
+
+	fastwc_log_info( 'Registered route: ' . FASTWC_ROUTES_BASE . '/authecho' );
 }
 add_action( 'rest_api_init', 'fastwc_rest_api_init' );
 
@@ -77,7 +85,11 @@ function fastwc_api_permission_callback() {
 	// handles the API consumer key and secret.
 	WC();
 
-	return current_user_can( 'manage_options' );
+	$has_permission = current_user_can( 'manage_options' );
+
+	fastwc_log_info( 'API Permission Callback: ' ( $has_permission ? 'granted' : 'denied' ) );
+
+	return $has_permission;
 }
 
 /**
@@ -101,6 +113,8 @@ function fastwc_test_authorization_header( $request ) {
 			$auth_header = $headers['authorization'];
 		}
 	}
+
+	fastwc_log_info( 'Authorization header endpoint called: ' . $auth_header );
 
 	return new WP_REST_Response( $auth_header, 200 );
 }

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -19,6 +19,8 @@ function fastwc_add_shortcodes() {
 
 	// Add cart checktout button shortcode.
 	add_shortcode( 'fast_cart', 'fastwc_shortcode_cart_button' );
+
+	fastwc_log_info( 'Initialized Fast shortcodes: fast_product and fast_cart' );
 }
 add_action( 'init', 'fastwc_add_shortcodes' );
 
@@ -80,6 +82,8 @@ function fastwc_shortcode_cart_button( $atts ) {
  * @return string
  */
 function fastwc_shortcode_button_template( $template, $atts ) {
+
+	fastwc_log_info( 'Rendering shortcode template: ' . $template );
 
 	// Start the output buffer.
 	ob_start();

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -36,6 +36,7 @@ function fastwc_load_template( $template_name, $args = array() ) {
 			 * @param array  $args         Array of args to pass to the tepmlate. Requires WP 5.5+.
 			 */
 			load_template( $location, false, $args );
+			fastwc_log_info( 'Loaded template: ' . $location );
 			return;
 		}
 	}
@@ -55,6 +56,8 @@ function fastwc_get_products_to_hide_buttons() {
 		for ( $i = 0; $i < $fastwc_count_products; $i++ ) {
 			$fastwc_hidden_products[ $i ] = (int) $fastwc_hidden_products[ $i ];
 		}
+
+		fastwc_log_info( 'Products fetched to hide buttons: ' . print_r( $fastwc_hidden_products, true ) ); // phpcs:ignore
 	}
 
 	return $fastwc_hidden_products;
@@ -74,7 +77,11 @@ function fastwc_product_is_supported( $product_id ) {
 	 * @param bool $is_supported Flag to pass through the filters to set if the product is supported.
 	 * @param int  $product_id   The ID of the product to check.
 	 */
-	return apply_filters( 'fastwc_product_is_supported', true, $product_id );
+	$is_supported = apply_filters( 'fastwc_product_is_supported', true, $product_id );
+
+	fastwc_log_info( 'Product is' . ( $is_supported ? '' : ' not' ) . ' supported: ' . $product_id );
+
+	return $is_supported;
 }
 
 /**
@@ -89,6 +96,8 @@ function fastwc_product_is_supported_if_no_addons( $is_supported, $product_id ) 
 	if ( fastwc_product_has_addons( $product_id ) ) {
 		$is_supported = false;
 	}
+
+	fastwc_log_info( 'Product is' . ( $is_supported ? '' : ' not' ) . ' supported after addon check: ' . $product_id );
 
 	return $is_supported;
 }
@@ -107,6 +116,8 @@ function fastwc_product_is_supported_if_not_grouped( $is_supported, $product_id 
 		$is_supported = false;
 	}
 
+	fastwc_log_info( 'Product is' . ( $is_supported ? '' : ' not' ) . ' supported after grouped check: ' . $product_id );
+
 	return $is_supported;
 }
 add_filter( 'fastwc_product_is_supported', 'fastwc_product_is_supported_if_not_grouped', 10, 2 );
@@ -123,6 +134,8 @@ function fastwc_product_is_supported_if_not_subscription( $is_supported, $produc
 	if ( fastwc_product_is_subscription( $product_id ) ) {
 		$is_supported = false;
 	}
+
+	fastwc_log_info( 'Product is' . ( $is_supported ? '' : ' not' ) . ' supported after subscription check: ' . $product_id );
 
 	return $is_supported;
 }
@@ -148,6 +161,8 @@ function fastwc_product_has_addons( $product_id ) {
 		}
 	}
 
+	fastwc_log_info( 'Product does' . ( $has_addons ? '' : ' not' ) . ' have addons: ' . $product_id );
+
 	return $has_addons;
 }
 
@@ -170,6 +185,8 @@ function fastwc_product_is_grouped( $product_id ) {
 		$is_grouped = true;
 	}
 
+	fastwc_log_info( 'Product is' . ( $is_grouped ? '' : ' not' ) . ' grouped: ' . $product_id );
+
 	return $is_grouped;
 }
 
@@ -183,12 +200,16 @@ function fastwc_product_is_grouped( $product_id ) {
 function fastwc_product_is_subscription( $product_id ) {
 	$product = wc_get_product( $product_id );
 
+	$is_subscription = false;
+
 	if (
 		is_a( $product, WC_Product_Subscription::class ) ||
 		is_a( $product, WC_Product_Variable_Subscription::class )
 	) {
-		return true;
+		$is_subscription = true;
 	}
+
+	fastwc_log_info( 'Product is' . ( $is_subscription ? '' : ' not' ) . ' a subscription: ' . $product_id );
 
 	return false;
 }


### PR DESCRIPTION
# Description

Add a debug mode that enables logging messages to a `fastwc-` log file using the WooCommerce logging mechanism.

# Testing instructions

1. Login to the [dev site admin](https://fasttestdev.wpcomstaging.com/wp-admin/).
2. Go to the [Fast settings page](https://fasttestdev.wpcomstaging.com/wp-admin/admin.php?page=fast).
3. Enable Debug Mode by checking the checkbox next to the debug mode setting.
4. Perform some tasks on the front end.
5. Go back to the admin and look at the [logs in WooCommerce](https://fasttestdev.wpcomstaging.com/wp-admin/admin.php?page=wc-status&tab=logs).
6. Verify that a `fastwc-` log exists and verify that logging occurred.
7. Go back to the Fast settings page and disable debug mode.

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`

@ilkerulutas this is ready for a review.