### PR TITLE
Fix syntax error

### DIFF
--- a/includes/routes.php
+++ b/includes/routes.php
@@ -87,7 +87,7 @@ function fastwc_api_permission_callback() {
 
 	$has_permission = current_user_can( 'manage_options' );
 
-	fastwc_log_info( 'API Permission Callback: ' ( $has_permission ? 'granted' : 'denied' ) );
+	fastwc_log_info( 'API Permission Callback: ' . ( $has_permission ? 'granted' : 'denied' ) );
 
 	return $has_permission;
 }


### PR DESCRIPTION
# Description

This fixes a syntax error in the logging call in the API permissions check.

# Testing instructions

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`