### PR TITLE
PINT-429 Check for WooCommerce before loading any files

### DIFF
--- a/fast.php
+++ b/fast.php
@@ -23,6 +23,21 @@ function fastwc_settings_admin_notice_woocommerce_not_installed() {
 	);
 }
 
+/**
+ * Check that the WooCommerce version is greater than a particular version.
+ *
+ * @param string $version The version number to compare.
+ *
+ * @return bool
+ */
+function fastwc_woocommerce_version_is_at_least( $version ) {
+	if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, $version, '>=' ) ) {
+		return true;
+	}
+
+	return false;
+}
+
 // Check whether the woocommerce plugin is active.
 $active_plugins = get_option( 'active_plugins', array() );
 if ( ! in_array( 'woocommerce/woocommerce.php', $active_plugins, true ) ) {

--- a/fast.php
+++ b/fast.php
@@ -13,39 +13,11 @@
 define( 'FASTWC_PATH', plugin_dir_path( __FILE__ ) );
 define( 'FASTWC_URL', plugin_dir_url( __FILE__ ) );
 
-/**
- * Prints the error message when woocommerce isn't installed.
- */
-function fastwc_settings_admin_notice_woocommerce_not_installed() {
-	printf(
-		'<div class="notice notice-error"><p>%s</p></div>',
-		esc_html__( "Your Fast plugin won't work without an active WooCommerce installation.", 'fast' )
-	);
-}
-
-/**
- * Check that the WooCommerce version is greater than a particular version.
- *
- * @param string $version The version number to compare.
- *
- * @return bool
- */
-function fastwc_woocommerce_version_is_at_least( $version ) {
-	if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, $version, '>=' ) ) {
-		return true;
-	}
-
-	return false;
-}
+// WooCommerce version utilities.
+require_once FASTWC_PATH . 'includes/version.php';
 
 // Check whether the woocommerce plugin is active.
-$active_plugins = get_option( 'active_plugins', array() );
-if ( ! in_array( 'woocommerce/woocommerce.php', $active_plugins, true ) ) {
-	add_action(
-		'admin_notices',
-		'fastwc_settings_admin_notice_woocommerce_not_installed'
-	);
-} else {
+if ( fastwc_woocommerce_is_active() ) {
 	// Fast debug functions.
 	require_once FASTWC_PATH . 'includes/debug.php';
 	// WP Admin plugin settings.

--- a/fast.php
+++ b/fast.php
@@ -13,19 +13,38 @@
 define( 'FASTWC_PATH', plugin_dir_path( __FILE__ ) );
 define( 'FASTWC_URL', plugin_dir_url( __FILE__ ) );
 
-// Fast debug functions.
-require_once FASTWC_PATH . 'includes/debug.php';
-// WP Admin plugin settings.
-require_once FASTWC_PATH . 'includes/admin/settings.php';
-// Loads Fast js and css assets.
-require_once FASTWC_PATH . 'includes/assets.php';
-// Loads fast utilities.
-require_once FASTWC_PATH . 'includes/utilities.php';
-// Adds Fast Checkout button to store.
-require_once FASTWC_PATH . 'includes/checkout.php';
-// Adds Fast Login button to store.
-require_once FASTWC_PATH . 'includes/login.php';
-// Registers routes for the plugin API endpoints.
-require_once FASTWC_PATH . 'includes/routes.php';
-// Add Fast button shortcodes.
-require_once FASTWC_PATH . 'includes/shortcodes.php';
+/**
+ * Prints the error message when woocommerce isn't installed.
+ */
+function fastwc_settings_admin_notice_woocommerce_not_installed() {
+	printf(
+		'<div class="notice notice-error"><p>%s</p></div>',
+		esc_html__( "Your Fast plugin won't work without an active WooCommerce installation.", 'fast' )
+	);
+}
+
+// Check whether the woocommerce plugin is active.
+$active_plugins = get_option( 'active_plugins', array() );
+if ( ! in_array( 'woocommerce/woocommerce.php', $active_plugins, true ) ) {
+	add_action(
+		'admin_notices',
+		'fastwc_settings_admin_notice_woocommerce_not_installed'
+	);
+} else {
+	// Fast debug functions.
+	require_once FASTWC_PATH . 'includes/debug.php';
+	// WP Admin plugin settings.
+	require_once FASTWC_PATH . 'includes/admin/settings.php';
+	// Loads Fast js and css assets.
+	require_once FASTWC_PATH . 'includes/assets.php';
+	// Loads fast utilities.
+	require_once FASTWC_PATH . 'includes/utilities.php';
+	// Adds Fast Checkout button to store.
+	require_once FASTWC_PATH . 'includes/checkout.php';
+	// Adds Fast Login button to store.
+	require_once FASTWC_PATH . 'includes/login.php';
+	// Registers routes for the plugin API endpoints.
+	require_once FASTWC_PATH . 'includes/routes.php';
+	// Add Fast button shortcodes.
+	require_once FASTWC_PATH . 'includes/shortcodes.php';
+}

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -31,22 +31,6 @@ function fastwc_admin_create_menu() {
 	$position   = 100;
 
 	add_menu_page( $page_title, $menu_title, $capability, $slug, $callback, $icon, $position );
-
-	// Check whether the woocommerce plugin is active.
-	$active_plugins = apply_filters( 'active_plugins', get_option( 'active_plugins' ) );
-	if ( ! in_array( 'woocommerce/woocommerce.php', $active_plugins, true ) ) {
-		add_action( 'admin_notices', 'fastwc_settings_admin_notice_woocommerce_not_installed' );
-	}
-}
-
-/**
- * Prints the error message when woocommerce isn't installed.
- */
-function fastwc_settings_admin_notice_woocommerce_not_installed() {
-	printf(
-		'<div class="notice notice-error"><p>%s</p></div>',
-		esc_html__( "Your Fast plugin won't work without an active WooCommerce installation.", 'fast' )
-	);
 }
 
 /**

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -46,22 +46,6 @@ function fastwc_admin_create_menu() {
 	register_setting( 'fast', FASTWC_SETTING_FAST_JWKS_URL );
 	register_setting( 'fast', FASTWC_SETTING_ONBOARDING_URL );
 	register_setting( 'fast', FASTWC_SETTING_DEBUG_MODE );
-
-	// Check whether the woocommerce plugin is active.
-	$active_plugins = apply_filters( 'active_plugins', get_option( 'active_plugins' ) );
-	if ( ! in_array( 'woocommerce/woocommerce.php', $active_plugins, true ) ) {
-		add_action( 'admin_notices', 'fastwc_settings_admin_notice_woocommerce_not_installed' );
-	}
-}
-
-/**
- * Prints the error message when woocommerce isn't installed.
- */
-function fastwc_settings_admin_notice_woocommerce_not_installed() {
-	printf(
-		'<div class="notice notice-error"><p>%s</p></div>',
-		esc_html__( "Your Fast plugin won't work without an active WooCommerce installation.", 'fast' )
-	);
 }
 
 /**

--- a/includes/debug.php
+++ b/includes/debug.php
@@ -13,7 +13,7 @@
 function fastwc_debug_mode_enabled() {
 	$fastwc_debug_mode = get_option( FASTWC_SETTING_DEBUG_MODE, 0 );
 
-	return ! empty( $fastwc_debug_mode );
+	return fastwc_woocommerce_version_is_at_least( '3.2' ) && ! empty( $fastwc_debug_mode );
 }
 
 /**
@@ -47,7 +47,7 @@ function fastwc_log( $level, $message ) {
  * @param string $message Message to log.
  */
 function fastwc_log_emergency( $message ) {
-	fastwc_log( WC_Log_Levels::EMERGENCY, $message );
+	fastwc_log( 'emergency', $message );
 }
 
 /**
@@ -61,7 +61,7 @@ function fastwc_log_emergency( $message ) {
  * @param string $message Message to log.
  */
 function fastwc_log_alert( $message ) {
-	fastwc_log( WC_Log_Levels::ALERT, $message );
+	fastwc_log( 'alert', $message );
 }
 
 /**
@@ -75,7 +75,7 @@ function fastwc_log_alert( $message ) {
  * @param string $message Message to log.
  */
 function fastwc_log_critical( $message ) {
-	fastwc_log( WC_Log_Levels::CRITICAL, $message );
+	fastwc_log( 'critical', $message );
 }
 
 /**
@@ -89,7 +89,7 @@ function fastwc_log_critical( $message ) {
  * @param string $message Message to log.
  */
 function fastwc_log_error( $message ) {
-	fastwc_log( WC_Log_Levels::ERROR, $message );
+	fastwc_log( 'error', $message );
 }
 
 /**
@@ -105,7 +105,7 @@ function fastwc_log_error( $message ) {
  * @param string $message Message to log.
  */
 function fastwc_log_warning( $message ) {
-	fastwc_log( WC_Log_Levels::WARNING, $message );
+	fastwc_log( 'warning', $message );
 }
 
 /**
@@ -118,7 +118,7 @@ function fastwc_log_warning( $message ) {
  * @param string $message Message to log.
  */
 function fastwc_log_notice( $message ) {
-	fastwc_log( WC_Log_Levels::NOTICE, $message );
+	fastwc_log( 'notice', $message );
 }
 
 /**
@@ -132,7 +132,7 @@ function fastwc_log_notice( $message ) {
  * @param string $message Message to log.
  */
 function fastwc_log_info( $message ) {
-	fastwc_log( WC_Log_Levels::INFO, $message );
+	fastwc_log( 'info', $message );
 }
 
 /**
@@ -145,5 +145,5 @@ function fastwc_log_info( $message ) {
  * @param string $message Message to log.
  */
 function fastwc_log_debug( $message ) {
-	fastwc_log( WC_Log_Levels::DEBUG, $message );
+	fastwc_log( 'debug', $message );
 }

--- a/includes/version.php
+++ b/includes/version.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Functions to check for WooCommerce and its version.
+ *
+ * @package Fast
+ */
+
+/**
+ * Check to see if WooCommerce is installed and active.
+ *
+ * @return bool
+ */
+function fastwc_woocommerce_is_active() {
+	$active_plugins = get_option( 'active_plugins', array() );
+	$wc_is_active   = in_array( 'woocommerce/woocommerce.php', $active_plugins, true );
+
+	if ( ! $wc_is_active ) {
+		// Add an admin notice that WooCommerce must be active in order for Fast to work.
+		add_action(
+			'admin_notices',
+			'fastwc_settings_admin_notice_woocommerce_not_installed'
+		);
+	}
+
+	return $wc_is_active;
+}
+
+/**
+ * Prints the error message when woocommerce isn't installed.
+ */
+function fastwc_settings_admin_notice_woocommerce_not_installed() {
+	printf(
+		'<div class="notice notice-error"><p>%s</p></div>',
+		esc_html__( "Your Fast plugin won't work without an active WooCommerce installation.", 'fast' )
+	);
+}
+
+/**
+ * Check that the WooCommerce version is greater than a particular version.
+ *
+ * @param string $version The version number to compare.
+ *
+ * @return bool
+ */
+function fastwc_woocommerce_version_is_at_least( $version ) {
+	if (
+		defined( 'WC_VERSION' ) &&
+		version_compare( WC_VERSION, $version, '>=' )
+	) {
+		return true;
+	}
+
+	return false;
+}


### PR DESCRIPTION
# Description

Moves the WooCommerce check to the Fast plugin entry point, and makes loading Fast plugin files contingent on the existence of an active WooCommerce installation.

# Testing instructions

1. Disable WooCommerce and verify that an admin alert message is displayed that says "Your Fast plugin won't work without an active WooCommerce installation."

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`