### PR TITLE
Bump the version to 1.0.7 and add a changelog

### DIFF
--- a/fast.php
+++ b/fast.php
@@ -3,7 +3,7 @@
  * Plugin Name: Fast Checkout for WooCommerce
  * Plugin URI: https://fast.co
  * Description: Install the Checkout button that increases conversion, boosts sales and delights customers.
- * Version: 1.0.6
+ * Version: 1.0.7
  * License: GPLv2
  * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  *

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: fast, fast checkout, checkout, woocommerce, woocommerce payment, woocommer
 Requires at least: 5.1
 Tested up to: 5.7
 Requires PHP: 7.2
-Stable tag: 1.0.6
+Stable tag: 1.0.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
  
@@ -34,6 +34,9 @@ Fast replaces your current payment processor. You can see our fee schedule, simi
 
  
 == Changelog ==
+
+= 1.0.7 =
+* Add tabs to the Fast settings page in the WordPress admin.
 
 = 1.0.6 =
 * Add an option to select the hook used to display the Fast Checkout button on product details pages.


### PR DESCRIPTION
# Description

Bump the plugin version to 1.0.7 and add a changelog.

# Testing instructions

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`