### PR TITLE
Update the plugin to version 1.0.8

### DIFF
--- a/fast.php
+++ b/fast.php
@@ -3,7 +3,7 @@
  * Plugin Name: Fast Checkout for WooCommerce
  * Plugin URI: https://fast.co
  * Description: Install the Checkout button that increases conversion, boosts sales and delights customers.
- * Version: 1.0.7
+ * Version: 1.0.8
  * License: GPLv2
  * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  *

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: fast, fast checkout, checkout, woocommerce, woocommerce payment, woocommer
 Requires at least: 5.1
 Tested up to: 5.7
 Requires PHP: 7.2
-Stable tag: 1.0.7
+Stable tag: 1.0.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
  
@@ -34,6 +34,13 @@ Fast replaces your current payment processor. You can see our fee schedule, simi
 
  
 == Changelog ==
+
+= 1.0.8 =
+* Require an active WooCommerce plugin before loading Fast and add notification indicating that WooCommerce is required.
+* Add ability to check for specific WooCommerce versions before loading certain features.
+* Add an option under Fast settings to allow the admin to choose where the store redirects after successful checkout.
+* Update the Fast settings page to use templates.
+* Add a support tab to include documentation and support ticket link.
 
 = 1.0.7 =
 * Add tabs to the Fast settings page in the WordPress admin.

--- a/templates/admin/tabs/fast-support.php
+++ b/templates/admin/tabs/fast-support.php
@@ -23,7 +23,7 @@ $image_urls = array(
 	<li><a href="#edit-appearance">Edit Appearance</a> | </li>
 	<li><a href="#button-options">Button Options</a> | </li>
 	<li><a href="#test-debug">Test and Debug</a> | </li>
-	<li><a href="https://help.fast.co/hc/en-us/requests/new" target="_blank" rel="noopener">Submit Ticket</a></li>
+	<li><a href="https://help.fast.co/hc/en-us" target="_blank" rel="noopener">Get Help</a></li>
 </ul>
 
 <div class="fast-support-docs">


### PR DESCRIPTION
# Description

Update the plugin version number to 1.0.8 and add a changelog. Update the "Submit Ticket" link to say "Get Help" and link to https://help.fast.co/hc/en-us.

# Testing instructions

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`