### PR TITLE
PINT-478 - Add test mode and debug mode admin notices

### DIFF
--- a/includes/admin/notices.php
+++ b/includes/admin/notices.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Display admin notices.
+ *
+ * @package Fast
+ */
+
+/**
+ * Check for conditions to display admin notices.
+ */
+function fastwc_maybe_display_admin_notices() {
+	$fastwc_debug_mode = get_option( FASTWC_SETTING_DEBUG_MODE, 0 );
+	$fastwc_test_mode  = get_option( FASTWC_SETTING_TEST_MODE, '1' );
+
+	if ( ! empty( $fastwc_debug_mode ) ) {
+		add_action( 'admin_notices', 'fastwc_settings_admin_notice_debug_mode' );
+	}
+
+	if ( ! empty( $fastwc_test_mode ) ) {
+		add_action( 'admin_notices', 'fastwc_settings_admin_notice_test_mode' );
+	}
+
+}
+add_action( 'admin_init', 'fastwc_maybe_display_admin_notices' );
+
+/**
+ * Template for printing an admin notice.
+ *
+ * @param string $message The message to display.
+ * @param string $type    Optional. The type of message to display.
+ */
+function fastwc_admin_notice( $message, $type = 'warning' ) {
+	$class = 'notice notice-' . $type;
+
+	printf(
+		'<div class="%1$s"><p>%2$s</p></div>',
+		esc_attr( $class ),
+		esc_html( $message )
+	);
+}
+
+/**
+ * Print the Test Mode admin notice.
+ */
+function fastwc_settings_admin_notice_test_mode() {
+	fastwc_admin_notice( __( 'Fast Checkout for WooCommerce is currently in Test Mode.', 'fast' ) );
+}
+
+/**
+ * Print the Debug Mode admin notice.
+ */
+function fastwc_settings_admin_notice_debug_mode() {
+	fastwc_admin_notice( __( 'Fast Checkout for WooCommerce is currently in Debug Mode.', 'fast' ) );
+}

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -7,6 +7,8 @@
  * @package Fast
  */
 
+// Load admin notices.
+require_once FASTWC_PATH . 'includes/admin/notices.php';
 // Load admin constants.
 require_once FASTWC_PATH . 'includes/admin/constants.php';
 // Load admin fields.


### PR DESCRIPTION
# Description

Display a notice in the WordPress admin when the Fast plugin is in Test Mode or Debug Mode. This will help the seller and the Fast CS/TCS team know more easily whether or not the plugin is in Test Mode or Debug Mode.

# Testing instructions

1. Login to the [staging admin](https://fasttestdev.wpcomstaging.com/wp-admin/).
2. Visit the [Fast settings page Test Mode tab](https://fasttestdev.wpcomstaging.com/wp-admin/admin.php?page=fast&tab=fast_test_mode).
3. Enable Test Mode.
4. Verify that a notice appears in the admin that says "Fast Checkout for WooCommerce is currently in Test Mode."
5. Enable Debug Mode.
6. Verify that a notice appears in the admin that says "Fast Checkout for WooCommerce is currently in Debug Mode."

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`

@ilkerulutas @brikr this is now ready for review.