### PR TITLE
Update the plugin to version 1.1.0

### DIFF
--- a/fast.php
+++ b/fast.php
@@ -3,7 +3,7 @@
  * Plugin Name: Fast Checkout for WooCommerce
  * Plugin URI: https://fast.co
  * Description: Install the Checkout button that increases conversion, boosts sales and delights customers.
- * Version: 1.0.8
+ * Version: 1.1.0
  * License: GPLv2
  * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  *
@@ -12,7 +12,7 @@
 
 define( 'FASTWC_PATH', plugin_dir_path( __FILE__ ) );
 define( 'FASTWC_URL', plugin_dir_url( __FILE__ ) );
-define( 'FASTWC_VERSION', '1.0.8' );
+define( 'FASTWC_VERSION', '1.1.0' );
 
 // WooCommerce version utilities.
 require_once FASTWC_PATH . 'includes/version.php';

--- a/includes/assets.php
+++ b/includes/assets.php
@@ -58,7 +58,7 @@ function fastwc_admin_enqueue_scripts() {
 		'fast-admin-css',
 		FASTWC_URL . 'assets/dist/styles.css',
 		array(),
-		$fast_js_version
+		FASTWC_VERSION
 	);
 }
 add_action( 'admin_enqueue_scripts', 'fastwc_admin_enqueue_scripts' );

--- a/includes/hide.php
+++ b/includes/hide.php
@@ -108,7 +108,7 @@ function fastwc_is_hidden_for_test_mode( $should_hide ) {
 
 		fastwc_log_info( 'Fast buttons' . ( $should_hide ? '' : ' not' ) . ' hidden for test mode.' );
 	}
- 
+
 	return $should_hide;
 }
 add_filter( 'fastwc_should_hide_pdp_checkout_button', 'fastwc_is_hidden_for_test_mode', 1 );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: fast, fast checkout, checkout, woocommerce, woocommerce payment, woocommer
 Requires at least: 5.1
 Tested up to: 5.7
 Requires PHP: 7.2
-Stable tag: 1.0.8
+Stable tag: 1.1.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
  
@@ -34,6 +34,14 @@ Fast replaces your current payment processor. You can see our fee schedule, simi
 
  
 == Changelog ==
+
+= 1.1.0 =
+* Add widgets to display the Fast Checkout and Fast Login buttons.
+* Add Gutenberg block types to display the Fast checkout and Fast Login buttons.
+* Add an option to prevent the Fast Login button from being displayed in the footer.
+* Display admin notices whenever the Fast plugin is in Test Mode or Debug Mode.
+* Add a footer to the Fast settings page that includes useful links and the latest version number of the plugin.
+* Replace inline admin CSS with enqueued CSS file.
 
 = 1.0.8 =
 * Require an active WooCommerce plugin before loading Fast and add notification indicating that WooCommerce is required.


### PR DESCRIPTION
# Description

Update the plugin version number to 1.1.0 and add a changelog.

# Testing instructions

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`