### PR TITLE
PINT-527 - Update button style loading

### DIFF
--- a/includes/admin/constants.php
+++ b/includes/admin/constants.php
@@ -13,6 +13,8 @@ define( 'FASTWC_SETTING_FAST_JWKS_URL', 'fast_fast_jwks_url' );
 define( 'FASTWC_SETTING_ONBOARDING_URL', 'fast_onboarding_url' );
 define( 'FASTWC_SETTING_DEBUG_MODE', 'fastwc_debug_mode' );
 define( 'FASTWC_SETTING_DEBUG_MODE_NOT_SET', 'fast debug mode not set' );
+define( 'FASTWC_SETTING_LOAD_BUTTON_STYLES', 'fastwc_load_button_styles' );
+define( 'FASTWC_SETTING_LOAD_BUTTON_STYLES_NOT_SET', 'fast load button styles not set' );
 define( 'FASTWC_SETTING_PDP_BUTTON_STYLES', 'fast_pdp_button_styles' );
 define( 'FASTWC_SETTING_CART_BUTTON_STYLES', 'fast_cart_button_styles' );
 define( 'FASTWC_SETTING_MINI_CART_BUTTON_STYLES', 'fast_mini_cart_button_styles' );

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -85,6 +85,7 @@ function fastwc_admin_setup_sections() {
 
 	$section_name = 'fast_styles';
 	add_settings_section( $section_name, '', false, $section_name );
+	register_setting( $section_name, FASTWC_SETTING_LOAD_BUTTON_STYLES );
 	register_setting( $section_name, FASTWC_SETTING_PDP_BUTTON_STYLES );
 	register_setting( $section_name, FASTWC_SETTING_CART_BUTTON_STYLES );
 	register_setting( $section_name, FASTWC_SETTING_MINI_CART_BUTTON_STYLES );
@@ -125,6 +126,7 @@ function fastwc_admin_setup_fields() {
 
 	// Button style settings.
 	$settings_section = 'fast_styles';
+	add_settings_field( FASTWC_SETTING_LOAD_BUTTON_STYLES, __( 'Load Button Styles', 'fast' ), 'fastwc_load_button_styles', $settings_section, $settings_section );
 	add_settings_field( FASTWC_SETTING_PDP_BUTTON_STYLES, __( 'Product page button styles', 'fast' ), 'fastwc_pdp_button_styles_content', $settings_section, $settings_section );
 	add_settings_field( FASTWC_SETTING_CART_BUTTON_STYLES, __( 'Cart page button styles', 'fast' ), 'fastwc_cart_button_styles_content', $settings_section, $settings_section );
 	add_settings_field( FASTWC_SETTING_MINI_CART_BUTTON_STYLES, __( 'Mini cart widget button styles', 'fast' ), 'fastwc_mini_cart_button_styles_content', $settings_section, $settings_section );
@@ -174,6 +176,29 @@ function fastwc_app_id_content() {
 			'name'        => 'fast_app_id',
 			'value'       => $fastwc_setting_app_id,
 			'description' => $description,
+		)
+	);
+}
+
+/**
+ * Renders a checkbox to set whether or not to load the button styles.
+ */
+function fastwc_load_button_styles() {
+	$fastwc_load_button_styles = get_option( FASTWC_SETTING_LOAD_BUTTON_STYLES, FASTWC_SETTING_LOAD_BUTTON_STYLES_NOT_SET );
+
+	if ( FASTWC_SETTING_LOAD_BUTTON_STYLES_NOT_SET === $fastwc_load_button_styles ) {
+		// If the option is FASTWC_SETTING_LOAD_BUTTON_STYLES_NOT_SET, then it hasn't yet been set. In this case, we
+		// want to configure it to true.
+		$fastwc_load_button_styles = '1';
+		update_option( FASTWC_SETTING_LOAD_BUTTON_STYLES, $fastwc_load_button_styles );
+	}
+
+	fastwc_settings_field_checkbox(
+		array(
+			'name'        => FASTWC_SETTING_LOAD_BUTTON_STYLES,
+			'current'     => $fastwc_load_button_styles,
+			'label'       => __( 'Load the button styles as configured in the settings.', 'fast' ),
+			'description' => __( 'When this box is checked, the styles configured below will be loaded to provide additional styling to the loading of the Fast buttons.', 'fast' ),
 		)
 	);
 }
@@ -498,7 +523,7 @@ function fastwc_onboarding_url_content() {
  */
 function fastwc_get_option_or_set_default( $option, $default ) {
 	$val = get_option( $option );
-	if ( $val ) {
+	if ( false === $val ) {
 		return $val;
 	}
 	update_option( $option, $default );

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -523,7 +523,7 @@ function fastwc_onboarding_url_content() {
  */
 function fastwc_get_option_or_set_default( $option, $default ) {
 	$val = get_option( $option );
-	if ( false === $val ) {
+	if ( false !== $val ) {
 		return $val;
 	}
 	update_option( $option, $default );

--- a/includes/assets.php
+++ b/includes/assets.php
@@ -67,6 +67,12 @@ add_action( 'admin_enqueue_scripts', 'fastwc_admin_enqueue_scripts' );
  * Load the styles in the head.
  */
 function fastwc_wp_head() {
+	$fastwc_load_button_styles = get_option( FASTWC_SETTING_LOAD_BUTTON_STYLES, false );
+
+	if ( empty( $fastwc_load_button_styles ) ) {
+		return;
+	}
+
 	$button_styles = array(
 		'pdp'       => get_option( FASTWC_SETTING_PDP_BUTTON_STYLES, '' ),
 		'mini_cart' => get_option( FASTWC_SETTING_MINI_CART_BUTTON_STYLES, '' ),

--- a/includes/assets.php
+++ b/includes/assets.php
@@ -64,6 +64,29 @@ function fastwc_admin_enqueue_scripts() {
 add_action( 'admin_enqueue_scripts', 'fastwc_admin_enqueue_scripts' );
 
 /**
+ * Load the styles in the head.
+ */
+function fastwc_wp_head() {
+	$button_styles = array(
+		'pdp'       => get_option( FASTWC_SETTING_PDP_BUTTON_STYLES, '' ),
+		'mini_cart' => get_option( FASTWC_SETTING_MINI_CART_BUTTON_STYLES, '' ),
+		'login'     => get_option( FASTWC_SETTING_LOGIN_BUTTON_STYLES, '' ),
+		'checkout'  => get_option( FASTWC_SETTING_CHECKOUT_BUTTON_STYLES, '' ),
+		'cart'      => get_option( FASTWC_SETTING_CART_BUTTON_STYLES, '' ),
+	);
+	?>
+<style>
+	<?php
+	foreach ( $button_styles as $button_style ) {
+		echo esc_html( $button_style ) . "\n";
+	}
+	?>
+</style>
+	<?php
+}
+add_action( 'wp_head', 'fastwc_wp_head' );
+
+/**
  * Enqueue block editor assets for the Gutenberg blocks.
  */
 function fastwc_enqueue_block_editor_assets() {

--- a/includes/assets.php
+++ b/includes/assets.php
@@ -67,7 +67,7 @@ add_action( 'admin_enqueue_scripts', 'fastwc_admin_enqueue_scripts' );
  * Load the styles in the head.
  */
 function fastwc_wp_head() {
-	$fastwc_load_button_styles = get_option( FASTWC_SETTING_LOAD_BUTTON_STYLES, false );
+	$fastwc_load_button_styles = get_option( FASTWC_SETTING_LOAD_BUTTON_STYLES, true );
 
 	if ( empty( $fastwc_load_button_styles ) ) {
 		return;

--- a/includes/assets.php
+++ b/includes/assets.php
@@ -73,20 +73,14 @@ function fastwc_wp_head() {
 		return;
 	}
 
-	$button_styles = array(
-		'pdp'       => get_option( FASTWC_SETTING_PDP_BUTTON_STYLES, '' ),
-		'mini_cart' => get_option( FASTWC_SETTING_MINI_CART_BUTTON_STYLES, '' ),
-		'login'     => get_option( FASTWC_SETTING_LOGIN_BUTTON_STYLES, '' ),
-		'checkout'  => get_option( FASTWC_SETTING_CHECKOUT_BUTTON_STYLES, '' ),
-		'cart'      => get_option( FASTWC_SETTING_CART_BUTTON_STYLES, '' ),
-	);
-	?>
-<style>
-	<?php
-	foreach ( $button_styles as $button_style ) {
-		echo esc_html( $button_style ) . "\n";
+	$button_styles = fastwc_get_button_styles();
+
+	if ( empty( $button_styles ) ) {
+		return;
 	}
 	?>
+<style>
+	<?php echo esc_html( $button_styles ); ?>
 </style>
 	<?php
 }

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -228,3 +228,33 @@ function fastwc_product_is_subscription( $product_id ) {
 
 	return false;
 }
+
+/**
+ * Get Fast button styles.
+ *
+ * @param mixed|string|array $button_type Type of styles to get. Default to empty string for all.
+ *
+ * @return string
+ */
+function fastwc_get_button_styles( $button_type = '' ) {
+	$types = array(
+		'pdp'       => FASTWC_SETTING_PDP_BUTTON_STYLES,
+		'mini_cart' => FASTWC_SETTING_MINI_CART_BUTTON_STYLES,
+		'login'     => FASTWC_SETTING_LOGIN_BUTTON_STYLES,
+		'checkout'  => FASTWC_SETTING_CHECKOUT_BUTTON_STYLES,
+		'cart'      => FASTWC_SETTING_CART_BUTTON_STYLES,
+	);
+
+	// If $button_type is empty, use all button types.
+	$button_type = '' === $button_type ? array_keys( $types ) : $button_type;
+	$button_type = is_array( $button_type ) ? $button_type : array( $button_type );
+
+	$button_styles = array();
+	foreach ( $button_type as $type ) {
+		if ( in_array( $type, array_keys( $types ), true ) ) {
+			$button_styles[] = get_option( $types[ $type ], '' );
+		}
+	}
+
+	return implode( "\n", $button_styles );
+}

--- a/templates/fast-cart.php
+++ b/templates/fast-cart.php
@@ -5,13 +5,9 @@
  * @package Fast
  */
 
-$fastwc_cart_button_styles = fastwc_get_option_or_set_default( FASTWC_SETTING_CART_BUTTON_STYLES, FASTWC_SETTING_CART_BUTTON_STYLES_DEFAULT );
 ?>
 
 		<div class="fast-cart-wrapper">
 			<?php fastwc_load_template( 'buttons/fast-checkout-cart-button' ); ?>
 			<div class="fast-cart-or"><?php esc_html_e( 'OR', 'fast' ); ?></div>
 		</div>
-		<style>
-			<?php echo esc_html( $fastwc_cart_button_styles ); ?>
-		</style>

--- a/templates/fast-checkout.php
+++ b/templates/fast-checkout.php
@@ -5,13 +5,9 @@
  * @package Fast
  */
 
-$fastwc_checkout_button_styles = fastwc_get_option_or_set_default( FASTWC_SETTING_CHECKOUT_BUTTON_STYLES, FASTWC_SETTING_CHECKOUT_BUTTON_STYLES_DEFAULT );
 ?>
 
 		<div class="fast-checkout-wrapper">
 			<?php fastwc_load_template( 'buttons/fast-checkout-cart-button' ); ?>
 			<div class="fast-checkout-or"><?php esc_html_e( 'OR', 'fast' ); ?></div>
 		</div>
-		<style>
-			<?php echo esc_html( $fastwc_checkout_button_styles ); ?>
-		</style>

--- a/templates/fast-login.php
+++ b/templates/fast-login.php
@@ -5,17 +5,13 @@
  * @package Fast
  */
 
-$fastwc_app_id              = fastwc_get_app_id();
-$fastwc_login_button_styles = fastwc_get_option_or_set_default( FASTWC_SETTING_LOGIN_BUTTON_STYLES, FASTWC_SETTING_LOGIN_BUTTON_STYLES_DEFAULT );
-$nonce                      = wp_create_nonce( 'fast-backend-login-auth' );
+$fastwc_app_id = fastwc_get_app_id();
+$nonce         = wp_create_nonce( 'fast-backend-login-auth' );
 ?>
 
 		<div class="fast-login-wrapper">
 			<fast-login id="fastloginbutton" app_id="<?php echo esc_attr( $fastwc_app_id ); ?>" data-nonce="<?php echo esc_attr( $nonce ); ?>"></fast-login>
 		</div>
-		<style>
-			<?php echo esc_html( $fastwc_login_button_styles ); ?>
-		</style>
 		<script type="text/javascript">
 			document
 			.querySelector("#fastloginbutton")

--- a/templates/fast-mini-cart.php
+++ b/templates/fast-mini-cart.php
@@ -5,13 +5,9 @@
  * @package Fast
  */
 
-$fastwc_mini_cart_button_styles = fastwc_get_option_or_set_default( FASTWC_SETTING_MINI_CART_BUTTON_STYLES, FASTWC_SETTING_MINI_CART_BUTTON_STYLES_DEFAULT );
 ?>
 
 		<div class="fast-mini-cart-wrapper">
 			<?php fastwc_load_template( 'buttons/fast-checkout-cart-button' ); ?>
 			<div class="fast-mini-cart-or"><?php esc_html_e( 'OR', 'fast' ); ?></div>
 		</div>
-		<style>
-			<?php echo esc_html( $fastwc_mini_cart_button_styles ); ?>
-		</style>

--- a/templates/fast-pdp.php
+++ b/templates/fast-pdp.php
@@ -5,8 +5,7 @@
  * @package Fast
  */
 
-$fastwc_pdp_button_styles = fastwc_get_option_or_set_default( FASTWC_SETTING_PDP_BUTTON_STYLES, FASTWC_SETTING_PDP_BUTTON_STYLES_DEFAULT );
-$fastwc_pdp_button_hook   = fastwc_get_pdp_button_hook();
+$fastwc_pdp_button_hook = fastwc_get_pdp_button_hook();
 ?>
 
 		<div class="fast-pdp-wrapper <?php echo esc_attr( $fastwc_pdp_button_hook ); ?>">
@@ -18,6 +17,3 @@ $fastwc_pdp_button_hook   = fastwc_get_pdp_button_hook();
 			<div class="fast-pdp-or"><?php esc_html_e( 'OR', 'fast' ); ?></div>
 			<?php endif; ?>
 		</div>
-		<style>
-				<?php echo esc_html( $fastwc_pdp_button_styles ); ?>
-		</style>


### PR DESCRIPTION
# Description

Update how the button styles are loaded. This moves the `<style>` tags into the `<head>` of the page rather than inline below the button. Also adds an option in the Styles tab in the Fast settings page that lets you disable styles altogether. That would allow for adding styles from the theme or some other different means.

See https://fastaf.atlassian.net/browse/PINT-527

# Testing instructions

1. Visit https://fasttestdev.wpcomstaging.com/
2. Verify that the Fast button styles are loaded in the `<head>` of each page rather than just below the button.
3. Login to the [admin](https://fasttestdev.wpcomstaging.com/wp-admin).
4. Visit the [Styles tab of the Fast settings page](https://fasttestdev.wpcomstaging.com/wp-admin/admin.php?page=fast&tab=fast_styles).
5. Uncheck the option for loading the styles.
6. Save the settings.
7. Visit the front end of the site and verify that the styles are not being loaded.

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`

@ilkerulutas @brikr this is ready for review.