### PR TITLE
PINT-560 - Update function to check for active WooCommerce

### DIFF
--- a/includes/version.php
+++ b/includes/version.php
@@ -11,8 +11,11 @@
  * @return bool
  */
 function fastwc_woocommerce_is_active() {
-	$active_plugins = get_option( 'active_plugins', array() );
-	$wc_is_active   = in_array( 'woocommerce/woocommerce.php', $active_plugins, true );
+	if ( ! function_exists( 'is_plugin_active' ) ) {
+		require_once ABSPATH . '/wp-admin/includes/plugin.php';
+	}
+
+	$wc_is_active = is_plugin_active( 'woocommerce/woocommerce.php' );
 
 	if ( ! $wc_is_active ) {
 		// Add an admin notice that WooCommerce must be active in order for Fast to work.


### PR DESCRIPTION
# Description

Update the function that checks for an active WooCommerce installation. Use the built-in `is_plugin_active()` function, which accounts for network-active plugins in a [WordPress Multisite](https://wordpress.org/support/article/glossary/#multisite) installation.

See [PINT-560](https://fastaf.atlassian.net/browse/PINT-560) for details.

# Testing instructions

1. [Set up a WordPress multisite](https://wordpress.org/support/article/create-a-network/)
2. Install WooCommerce
3. Network-activate WooCommerce
4. Install Fast Checkout
5. Activate the Fast plugin on 1 site in the network. Do not network-activate the Fast plugin.
6. Verify that the Fast plugin displays the error message "Your Fast plugin won't work without an active WooCommerce installation."
7. Update the Fast plugin with the code from this branch.
8. Verify that the Fast plugin loads and no longer displays the error message.

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`

@ilkerulutas @brikr this is ready for review.