### PR TITLE
Update version number to 1.1.2 and update change log

### DIFF
--- a/fast.php
+++ b/fast.php
@@ -3,7 +3,7 @@
  * Plugin Name: Fast Checkout for WooCommerce
  * Plugin URI: https://fast.co
  * Description: Install the Checkout button that increases conversion, boosts sales and delights customers.
- * Version: 1.1.1
+ * Version: 1.1.2
  * License: GPLv2
  * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  *
@@ -12,7 +12,7 @@
 
 define( 'FASTWC_PATH', plugin_dir_path( __FILE__ ) );
 define( 'FASTWC_URL', plugin_dir_url( __FILE__ ) );
-define( 'FASTWC_VERSION', '1.1.1' );
+define( 'FASTWC_VERSION', '1.1.2' );
 
 // WooCommerce version utilities.
 require_once FASTWC_PATH . 'includes/version.php';

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: fast, fast checkout, checkout, woocommerce, woocommerce payment, woocommer
 Requires at least: 5.1
 Tested up to: 5.8
 Requires PHP: 7.2
-Stable tag: 1.1.1
+Stable tag: 1.1.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
  
@@ -34,6 +34,9 @@ Fast replaces your current payment processor. You can see our fee schedule, simi
 
  
 == Changelog ==
+
+= 1.1.2 =
+* Update the function that checks for an active WooCommerce installation.
 
 = 1.1.1 =
 * Add API endpoint to support partial order refunds.


### PR DESCRIPTION
# Description

Update version number to 1.1.2 and update change log

# Testing instructions

N/A

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`