### PR TITLE
PINT-610 - Make sure the shipping object is not empty

### DIFF
--- a/includes/routes/class-shipping.php
+++ b/includes/routes/class-shipping.php
@@ -140,13 +140,26 @@ class Shipping extends Route {
 	 * @return mixed
 	 */
 	protected function update_customer_information( $params ) {
+		$shipping_param = ! empty( $params['shipping'] ) ? $params['shipping'] : array();
+		$shipping_param = wp_parse_args(
+			$shipping_param,
+			array(
+				'country'   => '',
+				'state'     => '',
+				'postcode'  => '',
+				'city'      => '',
+				'address_1' => '',
+				'address_2' => '',
+			)
+		);
+
 		$customer_props = array(
-			'shipping_country'   => $params['shipping']['country'],
-			'shipping_state'     => $params['shipping']['state'],
-			'shipping_postcode'  => $params['shipping']['postcode'],
-			'shipping_city'      => $params['shipping']['city'],
-			'shipping_address_1' => $params['shipping']['address_1'],
-			'shipping_address_2' => $params['shipping']['address_2'],
+			'shipping_country'   => $shipping_param['country'],
+			'shipping_state'     => $shipping_param['state'],
+			'shipping_postcode'  => $shipping_param['postcode'],
+			'shipping_city'      => $shipping_param['city'],
+			'shipping_address_1' => $shipping_param['address_1'],
+			'shipping_address_2' => $shipping_param['address_2'],
 		);
 
 		// Add billing address info if it is part of the request.


### PR DESCRIPTION
# Description

Getting undefined index error on shipping endpoint. See https://app.datadoghq.com/logs?query=trace_id%3A4620605341570033724&cols=core_host%2Ccore_service&event=AQAAAXuoL68kDAVpkQAAAABBWHVvTDdtT0FBREVnWVdfQ2NmRFJRQUM&index=&messageDisplay=inline&stream_sort=desc&from_ts=1630613293948&to_ts=1630615302725&live=false

We need to add validation to this code to make sure that the shipping object is not empty before trying to assign it to the `$customer_props` array.

# Testing instructions

Verify that the shipping endpoint is working properly in staging.

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`