### PR TITLE
PINT-640 - Update webhook check

### DIFF
--- a/includes/admin/notices.php
+++ b/includes/admin/notices.php
@@ -11,6 +11,7 @@
 function fastwc_maybe_display_admin_notices() {
 	$fastwc_debug_mode        = get_option( FASTWC_SETTING_DEBUG_MODE, 0 );
 	$fastwc_test_mode         = get_option( FASTWC_SETTING_TEST_MODE, '1' );
+	$fastwc_has_webhooks      = fastwc_woocommerce_has_fast_webhooks();
 	$fastwc_disabled_webhooks = fastwc_get_disabled_webhooks();
 
 	if ( ! empty( $fastwc_debug_mode ) ) {
@@ -19,6 +20,10 @@ function fastwc_maybe_display_admin_notices() {
 
 	if ( ! empty( $fastwc_test_mode ) ) {
 		add_action( 'admin_notices', 'fastwc_settings_admin_notice_test_mode' );
+	}
+
+	if ( ! $fastwc_has_webhooks ) {
+		add_action( 'admin_notices', 'fastwc_settings_admin_notice_missing_webhooks' );
 	}
 
 	if ( ! empty( $fastwc_disabled_webhooks ) ) {
@@ -62,4 +67,11 @@ function fastwc_settings_admin_notice_debug_mode() {
  */
 function fastwc_settings_admin_notice_disabled_webhooks() {
 	fastwc_admin_notice( __( 'One or more WooCommerce webhooks used by Fast Checkout for WooCommerce are disabled.', 'fast' ) );
+}
+
+/**
+ * Print the Missing Webhooks admin notice.
+ */
+function fastwc_settings_admin_notice_missing_webhooks() {
+	fastwc_admin_notice( __( 'One or more WooCommerce webhooks used by Fast Checkout for WooCommerce are missing.', 'fast' ) );
 }

--- a/includes/admin/notices.php
+++ b/includes/admin/notices.php
@@ -9,6 +9,7 @@
  * Check for conditions to display admin notices.
  */
 function fastwc_maybe_display_admin_notices() {
+	$fast_app_id              = fastwc_get_app_id();
 	$fastwc_debug_mode        = get_option( FASTWC_SETTING_DEBUG_MODE, 0 );
 	$fastwc_test_mode         = get_option( FASTWC_SETTING_TEST_MODE, '1' );
 	$fastwc_has_webhooks      = fastwc_woocommerce_has_fast_webhooks();
@@ -22,11 +23,11 @@ function fastwc_maybe_display_admin_notices() {
 		add_action( 'admin_notices', 'fastwc_settings_admin_notice_test_mode' );
 	}
 
-	if ( ! $fastwc_has_webhooks ) {
+	if ( ! empty( $fast_app_id ) && ! $fastwc_has_webhooks ) {
 		add_action( 'admin_notices', 'fastwc_settings_admin_notice_missing_webhooks' );
 	}
 
-	if ( ! empty( $fastwc_disabled_webhooks ) ) {
+	if ( ! empty( $fast_app_id ) && ! empty( $fastwc_disabled_webhooks ) ) {
 		add_action( 'admin_notices', 'fastwc_settings_admin_notice_disabled_webhooks' );
 	}
 }

--- a/includes/webhooks.php
+++ b/includes/webhooks.php
@@ -5,6 +5,7 @@
  * @package Fast
  */
 
+define( 'FASTWC_OPTION_WEBHOOKS', 'fastwc_webhooks' );
 define( 'FASTWC_OPTION_DISABLED_WEBHOOKS', 'fastwc_disabled_webhooks' );
 
 /**
@@ -29,11 +30,7 @@ function fastwc_get_fast_webhook_topics() {
  * @param int $webhook_id The ID of the webhook that was disabled.
  */
 function fastwc_woocommerce_webhook_disabled_due_delivery_failures( $webhook_id ) {
-	$webhook = wc_get_webhook( $webhook_id );
-
-	if ( fastwc_is_fast_webhook( $webhook ) ) {
-		fastwc_log_disabled_webhook( $webhook );
-	}
+	fastwc_maybe_log_disabled_webhook( $webhook_id );
 }
 add_action( 'woocommerce_webhook_disabled_due_delivery_failures', 'fastwc_woocommerce_webhook_disabled_due_delivery_failures' );
 
@@ -43,22 +40,27 @@ add_action( 'woocommerce_webhook_disabled_due_delivery_failures', 'fastwc_woocom
  * @param int $webhook_id The ID of the webhook that was saved.
  */
 function fastwc_woocommerce_webhook_options_save( $webhook_id ) {
-	$webhook = wc_get_webhook( $webhook_id );
-
-	// If the webhook is a Fast webhook and disabled, log it.
-	if ( fastwc_is_fast_webhook( $webhook ) && 'disabled' === $webhook->get_status() ) {
-		fastwc_log_disabled_webhook( $webhook );
-	}
-
-	// Get the list of disabled webhooks, and remove active webhooks from that list.
-	fastwc_get_disabled_webhooks();
+	fastwc_maybe_log_disabled_webhook( $webhook_id );
 }
 add_action( 'woocommerce_webhook_options_save', 'fastwc_woocommerce_webhook_options_save' );
+
+/**
+ * Check if the webhook is disabled.
+ *
+ * @param WC_Webhook $webhook The webhook to check.
+ *
+ * @return bool
+ */
+function fastwc_is_disabled_webhook( $webhook ) {
+	return 'disabled' === $webhook->get_status();
+}
 
 /**
  * Check if the webhook is a fast webhook.
  *
  * @param WC_Webhook $webhook The webhook to check.
+ *
+ * @return bool
  */
 function fastwc_is_fast_webhook( $webhook ) {
 	$fast_app_id   = fastwc_get_app_id();
@@ -91,17 +93,119 @@ function fastwc_get_disabled_webhooks() {
 	$disabled_webhooks = get_option( FASTWC_OPTION_DISABLED_WEBHOOKS, array() );
 
 	if ( ! empty( $disabled_webhooks ) ) {
+		$did_unset = false;
 		// Make sure that each webhook is still disabled.
 		foreach ( $disabled_webhooks as $webhook_topic => $webhook_id ) {
 			$webhook = wc_get_webhook( $webhook_id );
 
-			if ( ! empty( $webhook ) && 'disabled' !== $webhook->get_status() ) {
+			if ( ! empty( $webhook ) && ! fastwc_is_disabled_webhook( $webhook ) ) {
 				unset( $disabled_webhooks[ $webhook_topic ] );
+				$did_unset = true;
 			}
+		}
+
+		if ( $did_unset ) {
+			update_option( FASTWC_OPTION_DISABLED_WEBHOOKS, $disabled_webhooks, 'no' );
 		}
 	}
 
 	return $disabled_webhooks;
+}
+
+/**
+ * Get webhooks option.
+ *
+ * @return array
+ */
+function fastwc_get_webhooks_option() {
+	return get_option( FASTWC_OPTION_WEBHOOKS, array() );
+}
+
+/**
+ * Build a query to fetch webhooks.
+ *
+ * @return string
+ */
+function fastwc_build_webhook_query() {
+	global $wpdb;
+
+	$webhooks_option = fastwc_get_webhooks_option();
+
+	if ( ! empty( $webhooks_option ) ) {
+		$webhooks_ids = implode( ',', wp_parse_id_list( $webhooks_option ) );
+		$where_ids    = 'AND webhook_id IN ('  . $webhooks_ids . ')';
+
+		$query = trim(
+			"SELECT webhook_id
+			FROM {$wpdb->prefix}wc_webhooks
+			WHERE 1=1
+			{$where_ids}"
+		);
+	} else {
+		$webhooks_topics = fastwc_get_fast_webhook_topics();
+
+		// Create the WHERE clause of the query.
+		$topics_in          = array_map(
+			function( $topic ) {
+				$topic = sanitize_text_field( $topic );
+				return "'$topic'";
+			},
+			$webhooks_topics
+		);
+		$where_topic        = 'AND topic IN (' . implode( ',', $topics_in ) . ')';
+		$where_delivery_url = $wpdb->prepare( 'AND delivery_url LIKE %s', '%' . $wpdb->esc_like( sanitize_text_field( $fast_app_id ) ) . '%' );
+
+		$query = trim(
+			"SELECT webhook_id
+			FROM {$wpdb->prefix}wc_webhooks
+			WHERE 1=1
+			{$where_topic}
+			{$where_delivery_url}"
+		);
+	}
+
+	return $query;
+}
+
+/**
+ * Get a list of Fast webhooks.
+ *
+ * @return array
+ */
+function fastwc_get_fast_webhooks() {
+	$fast_app_id = fastwc_get_app_id();
+
+	// If there is no Fast App ID, there is no way to check for valid webhooks.
+	if ( empty( $fast_app_id ) ) {
+		return array();
+	}
+
+	$cache_key   = 'fast_webhooks_' . $fast_app_id;
+	$cache_group = 'fast_webhooks';
+	$cache_value = wp_cache_get( $cache_key, $cache_group );
+
+	if ( ! empty( $cache_value ) ) {
+		$webhooks = $cache_value;
+	} else {
+		global $wpdb;
+
+		$query    = fastwc_build_webhook_query();
+		$webhooks = wp_parse_id_list( $wpdb->get_col( $query ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		wp_cache_set( $cache_key, $webhooks, $cache_group );
+	}
+
+	if ( ! empty( $webhooks ) ) {
+		update_option( FASTWC_OPTION_WEBHOOKS, $webhooks, 'no' );
+
+		foreach ( $webhooks as $webhook_id ) {
+			fastwc_maybe_log_disabled_webhook( $webhook_id );
+		}
+	} else {
+		delete_option( FASTWC_OPTION_WEBHOOKS );
+	}
+
+	return $webhooks;
 }
 
 /**
@@ -110,11 +214,6 @@ function fastwc_get_disabled_webhooks() {
  * @return bool
  */
 function fastwc_woocommerce_has_fast_webhooks() {
-	// First, make sure the WC_Webhook_Data_Store class exists.
-	if ( ! class_exists( 'WC_Webhook_Data_Store' ) ) {
-		return false;
-	}
-
 	$fast_app_id = fastwc_get_app_id();
 
 	// If there is no Fast App ID, there is no way to check for valid webhooks.
@@ -122,14 +221,28 @@ function fastwc_woocommerce_has_fast_webhooks() {
 		return false;
 	}
 
-	gloal $wpdb;
+	$webhooks       = fastwc_get_fast_webhooks();
+	$webhooks_count = ! empty( $webhooks ) ? count( $webhooks ) : 0;
 
-	$webhooks_topics = fastwc_get_fast_webhook_topics();
+	if ( 6 <= $webhooks_count ) {
+		return true;
+	}
 
-	// Create the WHERE clause of the query.
-	$where_topic        = 'AND topic IN (' . implode( ',', $webhooks_topics ) . ')';
-	$where_delivery_url = $wpdb->prepare( 'AND delivery_url LIKE %s', '%' . $wpdb->esc_like( sanitize_text_field( $fast_app_id ) )  '%' );
+	return false;
+}
 
+/**
+ * Check if a webhook is disabled and log it.
+ *
+ * @param int $webhook_id The ID of the webhook to check and maybe log.
+ */
+function fastwc_maybe_log_disabled_webhook( $webhook_id ) {
+	$webhook = wc_get_webhook( $webhook_id );
+
+	// If the webhook is a Fast webhook and disabled, log it.
+	if ( fastwc_is_fast_webhook( $webhook ) && fastwc_is_disabled_webhook( $webhook ) ) {
+		fastwc_log_disabled_webhook( $webhook );
+	}
 }
 
 /**

--- a/includes/webhooks.php
+++ b/includes/webhooks.php
@@ -180,7 +180,7 @@ function fastwc_get_fast_webhooks() {
 		return array();
 	}
 
-	$cache_key   = 'fast_webhooks_' . $fast_app_id;
+	$cache_key   = 'fast_webhooks_cache_' . $fast_app_id;
 	$cache_group = 'fast_webhooks';
 	$cache_value = wp_cache_get( $cache_key, $cache_group );
 
@@ -192,7 +192,7 @@ function fastwc_get_fast_webhooks() {
 		$query    = fastwc_build_webhook_query();
 		$webhooks = wp_parse_id_list( $wpdb->get_col( $query ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
-		wp_cache_set( $cache_key, $webhooks, $cache_group );
+		wp_cache_set( $cache_key, $webhooks, $cache_group, DAY_IN_SECONDS );
 	}
 
 	if ( ! empty( $webhooks ) ) {

--- a/includes/webhooks.php
+++ b/includes/webhooks.php
@@ -192,7 +192,7 @@ function fastwc_get_fast_webhooks() {
 		$query    = fastwc_build_webhook_query();
 		$webhooks = wp_parse_id_list( $wpdb->get_col( $query ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
-		wp_cache_set( $cache_key, $webhooks, $cache_group, DAY_IN_SECONDS );
+		wp_cache_set( $cache_key, $webhooks, $cache_group, HOUR_IN_SECONDS );
 	}
 
 	if ( ! empty( $webhooks ) ) {

--- a/includes/webhooks.php
+++ b/includes/webhooks.php
@@ -209,6 +209,24 @@ function fastwc_get_fast_webhooks() {
 }
 
 /**
+ * Maybe clear the cache on the Fast webhooks cache.
+ */
+function fastwc_maybe_clear_fast_webhooks_cache() {
+	$fast_app_id               = fastwc_get_app_id();
+	$fast_clear_webhooks_cache = isset( $_GET['fast_clear_webhooks_cache'] ) ? absint( $_GET['fast_clear_webhooks_cache'] ) : false; // phpcs:ignore
+
+	if ( empty( $fast_app_id ) || ! $fast_clear_webhooks_cache ) {
+		return;
+	}
+
+	$cache_key   = 'fast_webhooks_cache_' . $fast_app_id;
+	$cache_group = 'fast_webhooks';
+
+	wp_cache_delete( $cache_key, $cache_group );
+}
+add_action( 'init', 'fastwc_maybe_clear_fast_webhooks_cache' );
+
+/**
  * Check to see if all Fast webhooks are installed and active.
  *
  * @return bool

--- a/includes/webhooks.php
+++ b/includes/webhooks.php
@@ -223,6 +223,7 @@ function fastwc_maybe_clear_fast_webhooks_cache() {
 	$cache_group = 'fast_webhooks';
 
 	wp_cache_delete( $cache_key, $cache_group );
+	delete_option( FASTWC_OPTION_WEBHOOKS );
 }
 add_action( 'init', 'fastwc_maybe_clear_fast_webhooks_cache' );
 

--- a/includes/webhooks.php
+++ b/includes/webhooks.php
@@ -63,7 +63,7 @@ function fastwc_is_disabled_webhook( $webhook ) {
  * @return bool
  */
 function fastwc_is_fast_webhook( $webhook ) {
-	$fast_app_id   = fastwc_get_app_id();
+	$fast_app_id = fastwc_get_app_id();
 
 	// If there is no Fast App ID, then the webhook is not a Fast webhook.
 	if ( empty( $fast_app_id ) ) {
@@ -133,7 +133,7 @@ function fastwc_build_webhook_query() {
 
 	if ( ! empty( $webhooks_option ) ) {
 		$webhooks_ids = implode( ',', wp_parse_id_list( $webhooks_option ) );
-		$where_ids    = 'AND webhook_id IN ('  . $webhooks_ids . ')';
+		$where_ids    = 'AND webhook_id IN (' . $webhooks_ids . ')';
 
 		$query = trim(
 			"SELECT webhook_id
@@ -190,7 +190,7 @@ function fastwc_get_fast_webhooks() {
 		global $wpdb;
 
 		$query    = fastwc_build_webhook_query();
-		$webhooks = wp_parse_id_list( $wpdb->get_col( $query ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$webhooks = wp_parse_id_list( $wpdb->get_col( $query ) ); // phpcs:ignore
 
 		wp_cache_set( $cache_key, $webhooks, $cache_group, HOUR_IN_SECONDS );
 	}

--- a/includes/webhooks.php
+++ b/includes/webhooks.php
@@ -66,7 +66,7 @@ function fastwc_is_fast_webhook( $webhook ) {
 	$fast_app_id   = fastwc_get_app_id();
 
 	// If there is no Fast App ID, then the webhook is not a Fast webhook.
-	if ( emtpy( $fast_app_id ) ) {
+	if ( empty( $fast_app_id ) ) {
 		return false;
 	}
 

--- a/templates/admin/tabs/fast-status.php
+++ b/templates/admin/tabs/fast-status.php
@@ -67,6 +67,7 @@ $fastwc_test_mode_class   = empty( $fastwc_test_mode ) ? 'dismiss' : 'yes-alt';
 				</td>
 			</tr>
 
+			<?php if ( ! empty( $fastwc_setting_app_id ) ) : ?>
 			<tr>
 				<td style="vertical-align: top;">
 					<p><strong><?php esc_html_e( 'Webhooks', 'fast' ); ?></strong></p>
@@ -91,6 +92,7 @@ $fastwc_test_mode_class   = empty( $fastwc_test_mode ) ? 'dismiss' : 'yes-alt';
 					<p><a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-settings&tab=advanced&section=webhooks' ) ); ?>"><?php esc_html_e( 'View all WooCommerce webhooks', 'fast' ); ?></a></p>
 				</td>
 			</tr>
+			<?php endif; ?>
 		</tbody>
 	</table>
 </div>

--- a/templates/admin/tabs/fast-status.php
+++ b/templates/admin/tabs/fast-status.php
@@ -8,6 +8,7 @@
 $fastwc_setting_app_id    = fastwc_get_app_id();
 $fastwc_debug_mode        = get_option( FASTWC_SETTING_DEBUG_MODE, 0 );
 $fastwc_test_mode         = get_option( FASTWC_SETTING_TEST_MODE, '1' );
+$fastwc_has_webhooks      = fastwc_woocommerce_has_fast_webhooks();
 $fastwc_disabled_webhooks = fastwc_get_disabled_webhooks();
 
 $status_enabled  = __( 'enabled', 'fast' );
@@ -36,10 +37,10 @@ $fastwc_test_mode_class   = empty( $fastwc_test_mode ) ? 'dismiss' : 'yes-alt';
 	<table class="form-table" role="presentation">
 		<tbody>
 			<tr>
-				<td>
+				<td style="vertical-align: top;">
 					<p><strong><?php esc_html_e( 'Fast App ID', 'fast' ); ?></strong></p>
 				</td>
-				<td>
+				<td style="vertical-align: top;">
 					<?php if ( ! empty( $fastwc_setting_app_id ) ) : ?>
 						<p><span class="dashicons dashicons-yes-alt"></span> <?php echo esc_html( $fastwc_setting_app_id ); ?></p>
 					<?php else : ?>
@@ -49,37 +50,43 @@ $fastwc_test_mode_class   = empty( $fastwc_test_mode ) ? 'dismiss' : 'yes-alt';
 			</tr>
 
 			<tr>
-				<td>
+				<td style="vertical-align: top;">
 					<p><strong><?php esc_html_e( 'Test Mode', 'fast' ); ?></strong></p>
 				</td>
-				<td>
+				<td style="vertical-align: top;">
 					<p><span class="dashicons dashicons-<?php echo esc_attr( $fastwc_test_mode_class ); ?>"></span> <?php echo esc_html( $fastwc_test_mode_status ); ?></p>
 				</td>
 			</tr>
 
 			<tr>
-				<td>
+				<td style="vertical-align: top;">
 					<p><strong><?php esc_html_e( 'Debug Mode', 'fast' ); ?></strong></p>
 				</td>
-				<td>
+				<td style="vertical-align: top;">
 					<p><span class="dashicons dashicons-<?php echo esc_attr( $fastwc_debug_mode_class ); ?>"></span> <?php echo esc_html( $fastwc_debug_mode_status ); ?></p>
 				</td>
 			</tr>
 
 			<tr>
-				<td>
+				<td style="vertical-align: top;">
 					<p><strong><?php esc_html_e( 'Webhooks', 'fast' ); ?></strong></p>
 				</td>
-				<td>
-					<?php if ( empty( $fastwc_disabled_webhooks ) ) : ?>
+				<td style="vertical-align: top;">
+					<?php if ( $fastwc_has_webhooks && empty( $fastwc_disabled_webhooks ) ) : ?>
 						<p><span class="dashicons dashicons-yes-alt"></span> <?php esc_html_e( 'All Fast webhooks are enabled.', 'fast' ); ?></p>
 					<?php else : ?>
+						<?php if ( ! $fastwc_has_webhooks ) : ?>
+						<p><span class="dashicons dashicons-dismiss"></span> <?php esc_html_e( 'One ore more Fast WooCommerce webhooks are missing.', 'fast' ); ?></p>
+						<?php endif; ?>
+
+						<?php if ( ! empty( $fastwc_disabled_webhooks ) ) : ?>
 						<p><span class="dashicons dashicons-dismiss"></span> <?php esc_html_e( 'The following Fast WooCommerce webhooks are disabled', 'fast' ); ?>:</p>
 						<ul class="ul-disc">
 						<?php foreach ( $fastwc_disabled_webhooks as $webhook_topic => $webhook_id ) : ?>
 							<li><?php echo esc_html( $webhook_topic ); ?></li>
 						<?php endforeach ?>
 						</ul>
+						<?php endif; ?>
 					<?php endif; ?>
 					<p><a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-settings&tab=advanced&section=webhooks' ) ); ?>"><?php esc_html_e( 'View all WooCommerce webhooks', 'fast' ); ?></a></p>
 				</td>


### PR DESCRIPTION
# Description

Update the webhook check to make sure that the webhooks are actually installed. The original webhook check assumed that the webhooks were properly installed and only check for disabled webhooks.

# Testing instructions

1. Login to the [staging server.](https://fasttestdev.wpcomstaging.com/wp-admin)
2. Remove one of the active webhooks.
3. Verify that a notice is displayed showing that a webhook is missing.

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`

@ilkerulutas @brik this is ready for a review.