### PR TITLE
PINT-661 - Add settings link to plugins page

### DIFF
--- a/fast.php
+++ b/fast.php
@@ -2,6 +2,8 @@
 /**
  * Plugin Name: Fast Checkout for WooCommerce
  * Plugin URI: https://fast.co
+ * Author: Fast
+ * Author URI: https://fast.co
  * Description: Install the Checkout button that increases conversion, boosts sales and delights customers.
  * Version: 1.1.5
  * License: GPLv2

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -19,6 +19,49 @@ add_action( 'admin_init', 'fastwc_admin_setup_sections' );
 add_action( 'admin_init', 'fastwc_admin_setup_fields' );
 
 /**
+ * Add plugin action links to the Fast plugin on the plugins page.
+ *
+ * @param array  $plugin_meta The list of links for the plugin.
+ * @param string $plugin_file Path to the plugin file relative to the plugins directory.
+ * @param array  $plugin_data An array of plugin data.
+ * @param string $status      Status filter currently applied to the plugin list. Possible
+ *                            values are: 'all', 'active', 'inactive', 'recently_activated',
+ *                            'upgrade', 'mustuse', 'dropins', 'search', 'paused',
+ *                            'auto-update-enabled', 'auto-update-disabled'.
+ *
+ * @return array
+ */
+function fastwc_admin_plugin_row_meta( $plugin_meta, $plugin_file, $plugin_data, $status ) {
+	if ( plugin_basename( FASTWC_PATH . 'fast.php' ) !== $plugin_file ) {
+		return $plugin_meta;
+	}
+
+	// Add "Become a Seller!" CTA if the Fast App ID has not yet been set.
+	if ( function_exists( 'fastwc_get_app_id' ) ) {
+		$fast_app_id = fastwc_get_app_id();
+
+		if ( empty( $fast_app_id ) ) {
+			$fastwc_setting_fast_onboarding_url = fastwc_get_option_or_set_default( FASTWC_SETTING_ONBOARDING_URL, FASTWC_ONBOARDING_URL );
+
+			$plugin_meta[] = sprintf(
+				'<a href="%1$s" target="_blank" rel="noopener"><strong>%2$s</strong></a>',
+				esc_url( $fastwc_setting_fast_onboarding_url ),
+				esc_html__( 'Become a Seller!', 'fast' )
+			);
+		}
+	}
+
+	$plugin_meta[] = sprintf(
+		'<a href="%1$s">%2$s</a>',
+		esc_url( admin_url( 'admin.php?page=fast' ) ),
+		esc_html__( 'Settings', 'fast' )
+	);
+
+	return $plugin_meta;
+}
+add_action( 'plugin_row_meta', 'fastwc_admin_plugin_row_meta', 10, 4 );
+
+/**
  * Registers the Fast menu within wp-admin.
  */
 function fastwc_admin_create_menu() {


### PR DESCRIPTION
# Description

This update adds links to the Fast settings page as well as a link to the Fast website from the Fast plugin listing in the plugins page of the admin.

# Testing instructions

1. Login to the [staging admin](https://fasttestdev.wpcomstaging.com/wp-admin).
2. Go to the [plugins page](https://fasttestdev.wpcomstaging.com/wp-admin/plugins.php).
3. Verify that the Fast Checkout for WooCommerce plugin listing now includes a link to the Fast website and the Fast settings page in the admin.

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`

@ilkerulutas @brikr this is ready for review.