### PR TITLE
PINT-662 - Redirect after activation

### DIFF
--- a/fast.php
+++ b/fast.php
@@ -42,3 +42,15 @@ if ( fastwc_woocommerce_is_active() ) {
 	// Add Fast failed/disabled webhook handler.
 	require_once FASTWC_PATH . 'includes/webhooks.php';
 }
+
+define( 'FASTWC_PLUGIN_ACTIVATED', 'fastwc_plugin_activated' );
+/**
+ * Add a flag indicating that the plugin was just activated.
+ */
+function fastwc_plugin_activated() {
+	// First make sure that WooCommerce is installed and active.
+	if ( fastwc_woocommerce_is_active() ) {
+		// Add a flag to show that the plugin was activated.
+		add_option( FASTWC_PLUGIN_ACTIVATED, true );
+	}
+}

--- a/fast.php
+++ b/fast.php
@@ -54,3 +54,4 @@ function fastwc_plugin_activated() {
 		add_option( FASTWC_PLUGIN_ACTIVATED, true );
 	}
 }
+register_activation_hook( __FILE__, 'fastwc_plugin_activated' );

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -42,13 +42,16 @@ function fastwc_maybe_redirect_after_activation() {
 	$activated = get_option( FASTWC_PLUGIN_ACTIVATED, false );
 
 	if ( $activated ) {
+		// Delete the flag to prevent an endless redirect loop.
 		delete_option( FASTWC_PLUGIN_ACTIVATED );
 
+		// Redirect to the Fast settings page.
 		wp_safe_redirect(
 			esc_url(
 				admin_url( 'admin.php?page=fast' )
 			)
 		);
+		exit;
 	}
 }
 

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -15,6 +15,7 @@ require_once FASTWC_PATH . 'includes/admin/constants.php';
 require_once FASTWC_PATH . 'includes/admin/fields.php';
 
 add_action( 'admin_menu', 'fastwc_admin_create_menu' );
+add_action( 'admin_init', 'fastwc_maybe_redirect_after_activation', 1 );
 add_action( 'admin_init', 'fastwc_admin_setup_sections' );
 add_action( 'admin_init', 'fastwc_admin_setup_fields' );
 
@@ -32,6 +33,23 @@ function fastwc_admin_create_menu() {
 	$position   = 100;
 
 	add_menu_page( $page_title, $menu_title, $capability, $slug, $callback, $icon, $position );
+}
+
+/**
+ * Maybe redirect to the Fast settings page after activation.
+ */
+function fastwc_maybe_redirect_after_activation() {
+	$activated = get_option( FASTWC_PLUGIN_ACTIVATED, false );
+
+	if ( $activated ) {
+		delete_option( FASTWC_PLUGIN_ACTIVATED );
+
+		wp_safe_redirect(
+			esc_url(
+				admin_url( 'admin.php?page=fast' )
+			)
+		);
+	}
 }
 
 /**


### PR DESCRIPTION
# Description

After the Fast plugin is activated, this update redirects the admin to the Fast settings page.

# Testing instructions

1. Login to the [staging admin](https://fasttestdev.wpcomstaging.com/wp-admin/).
2. Go to the [plugins page](https://fasttestdev.wpcomstaging.com/wp-admin/plugins.php).
3. Deactivate the Fast Checkout for WooCommerce plugin, and then activate it again.
4. Verify that you are redirected to the Fast settings page after activating the plugin.

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`

@ilkerulutas @brikr this is ready for review.