### PR TITLE
PINT-645 - Add setting timestamps

### DIFF
--- a/includes/admin/constants.php
+++ b/includes/admin/constants.php
@@ -31,6 +31,7 @@ define( 'FASTWC_SETTING_PDP_BUTTON_HOOK_OTHER', 'fast_pdp_button_hook_other' );
 define( 'FASTWC_JWKS_URL', 'https://api.fast.co/v1/oauth2/jwks' );
 define( 'FASTWC_JS_URL', 'https://js.fast.co/fast-woocommerce.js' );
 define( 'FASTWC_ONBOARDING_URL', 'https://fast.co/business' );
+define( 'FASTWC_SETTINGS_TIMESTAMPS', 'fastwc_settings_timestamps' );
 
 define(
 	'FASTWC_SETTING_PDP_BUTTON_STYLES_DEFAULT',

--- a/includes/admin/fields.php
+++ b/includes/admin/fields.php
@@ -5,245 +5,74 @@
  * @package Fast
  */
 
-/**
- * Get the field args.
- *
- * @param array $default_args The default args.
- * @param array $args         The field-specific args.
- *
- * @return array
- */
-function fastwc_get_field_args( $default_args, $args ) {
-	$defaults = array(
-		'name' => '',
-		'id'   => '',
-	);
-
-	$default_args = wp_parse_args( $default_args, $defaults );
-
-	$args = wp_parse_args( $args, $default_args );
-
-	// If the id is empty, set it equal to the name field.
-	if ( empty( $args['id'] ) ) {
-		$args['id'] = $args['name'];
-	}
-
-	return $args;
-}
-
-/**
- * Render a field description if it exists.
- *
- * @param string $description The field description.
- */
-function fastwc_maybe_render_field_description( $description ) {
-	if ( ! empty( $description ) ) :
-		?>
-	<p class="description"><?php echo wp_kses_post( $description ); ?></p>
-		<?php
-	endif;
-}
+// Load base field class.
+require_once FASTWC_PATH . 'includes/admin/fields/class-field.php';
+// Load input field class.
+require_once FASTWC_PATH . 'includes/admin/fields/class-input.php';
+// Load textarea field class.
+require_once FASTWC_PATH . 'includes/admin/fields/class-textarea.php';
+// Load checkbox field class.
+require_once FASTWC_PATH . 'includes/admin/fields/class-checkbox.php';
+// Load select field class.
+require_once FASTWC_PATH . 'includes/admin/fields/class-select.php';
+// Load image select field class.
+require_once FASTWC_PATH . 'includes/admin/fields/class-image-select.php';
+// Load ajax select field class.
+require_once FASTWC_PATH . 'includes/admin/fields/class-ajax-select.php';
 
 /**
  * Standard text input field.
  *
  * @param array $args Attribute args for the field.
+ *
+ * @return FastWC\Admin\Fields\Input
  */
 function fastwc_settings_field_input( $args ) {
-	$args = fastwc_get_field_args(
-		array(
-			'name'        => '',
-			'id'          => '',
-			'type'        => 'text',
-			'class'       => 'input-field',
-			'value'       => '',
-			'description' => '',
-		),
-		$args
-	);
-
-	// An input field with no name is invalid. Do nothing if the name is empty.
-	if ( empty( $args['name'] ) ) {
-		return;
-	}
-	?>
-	<input
-		name="<?php echo esc_attr( $args['name'] ); ?>"
-		id="<?php echo esc_attr( $args['id'] ); ?>"
-		type="<?php echo esc_attr( $args['type'] ); ?>"
-		class="<?php echo esc_attr( $args['class'] ); ?>"
-		value="<?php echo esc_attr( $args['value'] ); ?>"
-	/>
-	<?php
-	fastwc_maybe_render_field_description( $args['description'] );
+	return new FastWC\Admin\Fields\Input( $args );
 }
 
 /**
  * Standard textarea field.
  *
  * @param array $args Attribute args for the field.
+ *
+ * @return FastWC\Admin\Fields\Textarea
  */
 function fastwc_settings_field_textarea( $args ) {
-	$args = fastwc_get_field_args(
-		array(
-			'name'        => '',
-			'id'          => '',
-			'rows'        => '10',
-			'cols'        => '50',
-			'class'       => 'textarea-field',
-			'value'       => '',
-			'description' => '',
-		),
-		$args
-	);
-
-	// A textarea field with no name is invalid. Do nothing if the name is empty.
-	if ( empty( $args['name'] ) ) {
-		return;
-	}
-	?>
-	<textarea name="<?php echo esc_attr( $args['name'] ); ?>" id="<?php echo esc_attr( $args['id'] ); ?>" rows="<?php echo esc_attr( $args['rows'] ); ?>" cols="<?php echo esc_attr( $args['cols'] ); ?>"><?php echo esc_textarea( $args['value'] ); ?></textarea>
-	<?php
-	fastwc_maybe_render_field_description( $args['description'] );
+	return new FastWC\Admin\Fields\Textarea( $args );
 }
 
 /**
  * Standard checkbox input field.
  *
  * @param array $args Attribute args for the field.
+ *
+ * @return FastWC\Admin\Fields\Checkbox
  */
 function fastwc_settings_field_checkbox( $args ) {
-	$args = fastwc_get_field_args(
-		array(
-			'name'        => '',
-			'id'          => '',
-			'class'       => 'checkbox-field',
-			'value'       => '1',
-			'checked'     => 1,
-			'current'     => 0,
-			'label'       => '',
-			'description' => '',
-		),
-		$args
-	);
-
-	// A textarea field with no name is invalid. Do nothing if the name is empty.
-	if ( empty( $args['name'] ) ) {
-		return;
-	}
-	?>
-	<input
-		name="<?php echo esc_attr( $args['name'] ); ?>"
-		id="<?php echo esc_attr( $args['id'] ); ?>"
-		type="checkbox"
-		class="<?php echo esc_attr( $args['class'] ); ?>"
-		value="<?php echo esc_attr( $args['value'] ); ?>"
-		<?php checked( $args['checked'], $args['current'] ); ?>
-	/>
-	<label for="<?php echo esc_attr( $args['name'] ); ?>"><?php echo esc_html( $args['label'] ); ?></label>
-	<?php
-	fastwc_maybe_render_field_description( $args['description'] );
+	return new FastWC\Admin\Fields\Checkbox( $args );
 }
 
 /**
  * Regular select settings field.
  *
  * @param array $args Attribute args for the field.
+ *
+ * @return FastWC\Admin\Fields\Select
  */
 function fastwc_settings_field_select( $args ) {
-	$args = fastwc_get_field_args(
-		array(
-			'name'        => '',
-			'id'          => '',
-			'class'       => 'fast-select',
-			'description' => '',
-			'options'     => array(),
-			'value'       => '',
-		),
-		$args
-	);
-
-	// A select field with no name or no options is invalid.
-	if ( empty( $args['name'] ) || empty( $args['options'] ) ) {
-		return;
-	}
-	?>
-	<select
-		class="<?php echo esc_attr( $args['class'] ); ?>"
-		name="<?php echo esc_attr( $args['name'] ); ?>"
-		id="<?php echo esc_attr( $args['id'] ); ?>"
-	>
-	<?php
-	foreach ( $args['options'] as $value => $label ) :
-		?>
-	<option value="<?php echo esc_attr( $value ); ?>" <?php selected( $args['value'], $value ); ?>><?php echo esc_html( $label ); ?></option>
-		<?php
-	endforeach;
-	?>
-	</select>
-	<?php
-	fastwc_maybe_render_field_description( $args['description'] );
+	return new FastWC\Admin\Fields\Select( $args );
 }
 
 /**
  * Image select settings field.
  *
  * @param array $args Attribute args for the field.
+ *
+ * @return FastWC\Admin\Fields\Image_Select
  */
 function fastwc_settings_field_image_select( $args ) {
-	$args = fastwc_get_field_args(
-		array(
-			'name'        => '',
-			'id'          => '',
-			'class'       => 'fast-select',
-			'description' => '',
-			'options'     => array(),
-			'value'       => '',
-		),
-		$args
-	);
-
-	// A select field with no name or no options is invalid.
-	if ( empty( $args['name'] ) || empty( $args['options'] ) ) {
-		return;
-	}
-
-	fastwc_maybe_render_field_description( $args['description'] );
-	?>
-	<div class="fast-image-select" id="fast-image-select-<?php echo esc_attr( $args['name'] ); ?>">
-	<?php
-	$index = 0;
-	foreach ( $args['options'] as $value => $option ) :
-		$label = ! empty( $option['label'] ) ? $option['label'] : '';
-		$image = ! empty( $option['image'] ) ? $option['image'] : '';
-		$id    = $args['name'] . '-' . $index;
-		$index++;
-		?>
-		<div class="fast-image-select--item">
-			<input
-				type="radio"
-				name="<?php echo esc_attr( $args['name'] ); ?>"
-				id="<?php echo esc_attr( $id ); ?>"
-				class="fast-image-select--input screen-reader-text"
-				value="<?php echo esc_attr( $value ); ?>"
-				<?php checked( $args['value'], $value ); ?>
-			/>
-			<label
-				for="<?php echo esc_attr( $id ); ?>"
-				class="fast-image-select--label"
-				aria-label="<?php echo esc_attr( $label ); ?>"
-			>
-				<span class="fast-image-select--label-text"><?php echo esc_html( $label ); ?></span>
-				<?php if ( ! empty( $image ) ) : ?>
-				<img src="<?php echo esc_url( $image ); ?>" class="fast-image-select--image" alt="<?php echo esc_attr( $label ); ?>" />
-				<?php endif; ?>
-			</label>
-		</div>
-			<?php
-	endforeach;
-	?>
-	</div>
-	<?php
+	return new FastWC\Admin\Fields\Image_Select( $args );
 }
 
 
@@ -251,52 +80,9 @@ function fastwc_settings_field_image_select( $args ) {
  * Ajax select settings field.
  *
  * @param array $args Attribute args for the field.
+ *
+ * @return FastWC\Admin\Fields\Ajax_Select
  */
 function fastwc_settings_field_ajax_select( $args ) {
-	$args = fastwc_get_field_args(
-		array(
-			'name'        => '',
-			'id'          => '',
-			'class'       => 'fast-select',
-			'description' => '',
-			'nonce'       => '',
-			'selected'    => array(),
-			'style'       => 'width: 400px;',
-			'multiple'    => true,
-		),
-		$args
-	);
-
-	// A textarea field with no name is invalid. Do nothing if the name is empty.
-	// For security purposes, a nonce must be added as well.
-	if ( empty( $args['name'] ) || empty( $args['nonce'] ) ) {
-		return;
-	}
-	$multiple = '';
-	$el_name  = $args['name'];
-	if ( true === $args['multiple'] ) {
-		$multiple = 'multiple';
-		$el_name .= '[]';
-	}
-	?>
-	<select
-		data-security="<?php echo esc_attr( wp_create_nonce( $args['nonce'] ) ); ?>"
-		<?php echo esc_attr( $multiple ); ?>
-		class="<?php echo esc_attr( $args['class'] ); ?>"
-		name="<?php echo esc_attr( $el_name ); ?>"
-		id="<?php echo esc_attr( $args['id'] ); ?>"
-		style="<?php echo esc_attr( $args['style'] ); ?>"
-	>
-	<?php
-	if ( ! empty( $args['selected'] ) ) :
-		foreach ( $args['selected'] as $value => $label ) :
-			?>
-		<option value="<?php echo esc_attr( $value ); ?>" selected="selected"><?php echo esc_html( $label ); ?></option>
-			<?php
-		endforeach;
-	endif;
-	?>
-	</select>
-	<?php
-	fastwc_maybe_render_field_description( $args['description'] );
+	return new FastWC\Admin\Fields\Ajax_Select( $args );
 }

--- a/includes/admin/fields/class-ajax-select.php
+++ b/includes/admin/fields/class-ajax-select.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * AJAX Select field class.
+ *
+ * @package Fast
+ */
+
+namespace FastWC\Admin\Fields;
+
+/**
+ * AJAX Select field class.
+ */
+class Ajax_Select extends Field {
+
+	/**
+	 * Validate the args before rendering.
+	 *
+	 * @return bool
+	 */
+	protected function should_do_render() {
+		if ( empty( $this->args['nonce'] ) ) {
+			return false;
+		}
+
+		return parent::should_do_render();
+	}
+
+	/**
+	 * Get the default args for the field type.
+	 *
+	 * @return array
+	 */
+	protected function get_default_args() {
+		return array(
+			'name'        => '',
+			'id'          => '',
+			'class'       => 'fast-select',
+			'description' => '',
+			'nonce'       => '',
+			'selected'    => array(),
+			'style'       => 'width: 400px;',
+			'multiple'    => true,
+		);
+	}
+
+	/**
+	 * Render the field.
+	 */
+	protected function render() {
+		$multiple = '';
+		$el_name  = $this->args['name'];
+		if ( true === $this->args['multiple'] ) {
+			$multiple = 'multiple';
+			$el_name .= '[]';
+		}
+		?>
+		<select
+			data-security="<?php echo \esc_attr( wp_create_nonce( $this->args['nonce'] ) ); ?>"
+			<?php echo \esc_attr( $multiple ); ?>
+			class="<?php echo \esc_attr( $this->args['class'] ); ?>"
+			name="<?php echo \esc_attr( $el_name ); ?>"
+			id="<?php echo \esc_attr( $this->args['id'] ); ?>"
+			style="<?php echo \esc_attr( $this->args['style'] ); ?>"
+		>
+		<?php
+		if ( ! empty( $this->args['selected'] ) ) :
+			foreach ( $this->args['selected'] as $value => $label ) :
+				?>
+			<option value="<?php echo \esc_attr( $value ); ?>" selected="selected"><?php echo \esc_html( $label ); ?></option>
+				<?php
+			endforeach;
+		endif;
+		?>
+		</select>
+		<?php
+	}
+}

--- a/includes/admin/fields/class-checkbox.php
+++ b/includes/admin/fields/class-checkbox.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Checkbox field class.
+ *
+ * @package Fast
+ */
+
+namespace FastWC\Admin\Fields;
+
+/**
+ * Checkbox field class.
+ */
+class Checkbox extends Field {
+
+	/**
+	 * Get the default args for the field type.
+	 *
+	 * @return array
+	 */
+	protected function get_default_args() {
+		return array(
+			'name'        => '',
+			'id'          => '',
+			'class'       => 'checkbox-field',
+			'value'       => '1',
+			'checked'     => 1,
+			'current'     => 0,
+			'label'       => '',
+			'description' => '',
+		);
+	}
+
+	/**
+	 * Render the field.
+	 */
+	protected function render() {
+		?>
+		<input
+			name="<?php echo \esc_attr( $this->args['name'] ); ?>"
+			id="<?php echo \esc_attr( $this->args['id'] ); ?>"
+			type="checkbox"
+			class="<?php echo \esc_attr( $this->args['class'] ); ?>"
+			value="<?php echo \esc_attr( $this->args['value'] ); ?>"
+			<?php \checked( $this->args['checked'], $this->args['current'] ); ?>
+		/>
+		<label for="<?php echo \esc_attr( $this->args['name'] ); ?>"><?php echo \esc_html( $this->args['label'] ); ?></label>
+		<?php
+	}
+}

--- a/includes/admin/fields/class-field.php
+++ b/includes/admin/fields/class-field.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Base field class.
+ *
+ * @package Fast
+ */
+
+namespace FastWC\Admin\Fields;
+
+/**
+ * Base field class.
+ */
+abstract class Field {
+
+	/**
+	 * Field args.
+	 *
+	 * @var array
+	 */
+	protected $args = array();
+
+	/**
+	 * Field constructor.
+	 *
+	 * @param array $args The args that define the field.
+	 */
+	public function __construct( $args ) {
+		$this->set_field_args( $args );
+
+		// First make sure all required args are present.
+		if ( ! $this->should_do_render() ) {
+			return;
+		}
+
+		$this->do_render();
+	}
+
+	/**
+	 * Validate the args before rendering.
+	 *
+	 * @return bool
+	 */
+	protected function should_do_render() {
+		if ( empty( $this->args['name'] ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Render the field, description, and timestamp.
+	 */
+	protected function do_render() {
+		$this->render();
+		$this->maybe_render_description();
+		$this->maybe_render_timestamp();
+	}
+
+	/**
+	 * Get the default args for the field type.
+	 *
+	 * @return array
+	 */
+	protected function get_default_args() {
+		return array();
+	}
+
+	/**
+	 * Set the field args.
+	 *
+	 * @param array $args The args passed into the field.
+	 */
+	protected function set_field_args( $args ) {
+		$defaults = array(
+			'name' => '',
+			'id'   => '',
+		);
+
+		$default_args = wp_parse_args( $this->get_default_args(), $defaults );
+
+		$args = wp_parse_args( $args, $default_args );
+
+		// If the id is empty, set it equal to the name field.
+		if ( empty( $args['id'] ) ) {
+			$args['id'] = $args['name'];
+		}
+
+		// Set the class $args variable.
+		$this->args = $args;
+	}
+
+	/**
+	 * Render the field.
+	 */
+	abstract protected function render();
+
+	/**
+	 * Maybe render the field description.
+	 */
+	protected function maybe_render_description() {
+		if ( empty( $this->args['description'] ) ) {
+			return;
+		}
+		?>
+		<p class="description"><?php echo \wp_kses_post( $this->args['description'] ); ?></p>
+		<?php
+	}
+
+	/**
+	 * Maybe render a last updated timestamp.
+	 */
+	protected function maybe_render_timestamp() {
+		// Check for timestamp and render if available.
+		$fastwc_timestamps = \get_option( FASTWC_SETTINGS_TIMESTAMPS, array() );
+
+		if ( empty( $fastwc_timestamps ) || empty( $fastwc_timestamps[ $this->args['name'] ] ) ) {
+			return;
+		}
+
+		$timestamp           = $fastwc_timestamps[ $this->args['name'] ];
+		$formatted_timestamp = sprintf(
+			/* translators: 1: Last modified date, 2: Last modified time. */
+			__( '%1$s at %2$s' ),
+			/* translators: Last modified date format. See https://www.php.net/manual/datetime.format.php */
+			date( __( 'Y/m/d' ), $timestamp ),
+			/* translators: Last modified time format. See https://www.php.net/manual/datetime.format.php */
+			date( __( 'g:i a' ), $timestamp )
+		);
+		?>
+		<p class="description fastwc-setting-timestamp"><small><em><?php esc_html_e( 'Last updated', 'fast' ); ?>: <?php echo esc_html( $formatted_timestamp ); ?></em></small></p>
+		<?php
+	}
+}

--- a/includes/admin/fields/class-image-select.php
+++ b/includes/admin/fields/class-image-select.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Image Select field class.
+ *
+ * @package Fast
+ */
+
+namespace FastWC\Admin\Fields;
+
+/**
+ * Image Select field class.
+ */
+class Image_Select extends Select {
+
+	/**
+	 * Render the field, description, and timestamp.
+	 */
+	protected function do_render() {
+		$this->maybe_render_description();
+		$this->maybe_render_timestamp();
+		$this->render();
+	}
+
+	/**
+	 * Render the field.
+	 */
+	protected function render() {
+		?>
+		<div class="fast-image-select" id="fast-image-select-<?php echo \esc_attr( $this->args['name'] ); ?>">
+		<?php
+		$index = 0;
+		foreach ( $this->args['options'] as $value => $option ) :
+			$label = ! empty( $option['label'] ) ? $option['label'] : '';
+			$image = ! empty( $option['image'] ) ? $option['image'] : '';
+			$id    = $this->args['name'] . '-' . $index;
+			$index++;
+			?>
+			<div class="fast-image-select--item">
+				<input
+					type="radio"
+					name="<?php echo \esc_attr( $this->args['name'] ); ?>"
+					id="<?php echo \esc_attr( $id ); ?>"
+					class="fast-image-select--input screen-reader-text"
+					value="<?php echo \esc_attr( $value ); ?>"
+					<?php \checked( $this->args['value'], $value ); ?>
+				/>
+				<label
+					for="<?php echo \esc_attr( $id ); ?>"
+					class="fast-image-select--label"
+					aria-label="<?php echo \esc_attr( $label ); ?>"
+				>
+					<span class="fast-image-select--label-text"><?php echo \esc_html( $label ); ?></span>
+					<?php if ( ! empty( $image ) ) : ?>
+					<img src="<?php echo \esc_url( $image ); ?>" class="fast-image-select--image" alt="<?php echo \esc_attr( $label ); ?>" />
+					<?php endif; ?>
+				</label>
+			</div>
+				<?php
+		endforeach;
+		?>
+		</div>
+		<?php
+	}
+}

--- a/includes/admin/fields/class-input.php
+++ b/includes/admin/fields/class-input.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Input field class.
+ *
+ * @package Fast
+ */
+
+namespace FastWC\Admin\Fields;
+
+/**
+ * Input field class.
+ */
+class Input extends Field {
+
+	/**
+	 * Get the default args for the field type.
+	 *
+	 * @return array
+	 */
+	protected function get_default_args() {
+		return array(
+			'name'        => '',
+			'id'          => '',
+			'type'        => 'text',
+			'class'       => 'input-field',
+			'value'       => '',
+			'description' => '',
+		);
+	}
+
+	/**
+	 * Render the field.
+	 */
+	protected function render() {
+		?>
+		<input
+			name="<?php echo \esc_attr( $this->args['name'] ); ?>"
+			id="<?php echo \esc_attr( $this->args['id'] ); ?>"
+			type="<?php echo \esc_attr( $this->args['type'] ); ?>"
+			class="<?php echo \esc_attr( $this->args['class'] ); ?>"
+			value="<?php echo \esc_attr( $this->args['value'] ); ?>"
+		/>
+		<?php
+	}
+}

--- a/includes/admin/fields/class-select.php
+++ b/includes/admin/fields/class-select.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Select field class.
+ *
+ * @package Fast
+ */
+
+namespace FastWC\Admin\Fields;
+
+/**
+ * Select field class.
+ */
+class Select extends Field {
+
+	/**
+	 * Validate the args before rendering.
+	 *
+	 * @return bool
+	 */
+	protected function should_do_render() {
+		if ( empty( $this->args['options'] ) ) {
+			return false;
+		}
+
+		return parent::should_do_render();
+	}
+
+	/**
+	 * Get the default args for the field type.
+	 *
+	 * @return array
+	 */
+	protected function get_default_args() {
+		return array(
+			'name'        => '',
+			'id'          => '',
+			'class'       => 'fast-select',
+			'description' => '',
+			'options'     => array(),
+			'value'       => '',
+		);
+	}
+
+	/**
+	 * Render the field.
+	 */
+	protected function render() {
+		?>
+		<select
+			class="<?php echo \esc_attr( $this->args['class'] ); ?>"
+			name="<?php echo \esc_attr( $this->args['name'] ); ?>"
+			id="<?php echo \esc_attr( $this->rgs['id'] ); ?>"
+		>
+		<?php
+		foreach ( $this->args['options'] as $value => $label ) :
+			?>
+		<option value="<?php echo \esc_attr( $value ); ?>" <?php \selected( $this->args['value'], $value ); ?>><?php echo \esc_html( $label ); ?></option>
+			<?php
+		endforeach;
+		?>
+		</select>
+		<?php
+	}
+}

--- a/includes/admin/fields/class-textarea.php
+++ b/includes/admin/fields/class-textarea.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Textarea field class.
+ *
+ * @package Fast
+ */
+
+namespace FastWC\Admin\Fields;
+
+/**
+ * Textarea field class.
+ */
+class Textarea extends Field {
+
+	/**
+	 * Get the default args for the field type.
+	 *
+	 * @return array
+	 */
+	protected function get_default_args() {
+		return array(
+			'name'        => '',
+			'id'          => '',
+			'rows'        => '10',
+			'cols'        => '50',
+			'class'       => 'textarea-field',
+			'value'       => '',
+			'description' => '',
+		);
+	}
+
+	/**
+	 * Render the field.
+	 */
+	protected function render() {
+		?>
+		<textarea
+			name="<?php echo \esc_attr( $this->args['name'] ); ?>"
+			id="<?php echo \esc_attr( $this->args['id'] ); ?>"
+			rows="<?php echo \esc_attr( $this->args['rows'] ); ?>"
+			cols="<?php echo \esc_attr( $this->args['cols'] ); ?>"><?php echo \esc_textarea( $this->args['value'] ); ?></textarea>
+		<?php
+	}
+}

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -14,6 +14,44 @@ require_once FASTWC_PATH . 'includes/admin/constants.php';
 // Load admin fields.
 require_once FASTWC_PATH . 'includes/admin/fields.php';
 
+/**
+ * Add timestamp when an option is updated.
+ *
+ * @param string $option    Name of the updated option.
+ * @param mixed  $old_value The old option value.
+ * @param mixed  $value     The new option value.
+ */
+function fastwc_updated_option( $option, $old_value, $value ) {
+	if ( $old_value === $value ) {
+		return;
+	}
+
+	$stampable_options = array(
+		FASTWC_SETTING_APP_ID,
+		FASTWC_SETTING_FAST_JS_URL,
+		FASTWC_SETTING_FAST_JWKS_URL,
+		FASTWC_SETTING_ONBOARDING_URL,
+		FASTWC_SETTING_PDP_BUTTON_STYLES,
+		FASTWC_SETTING_CART_BUTTON_STYLES,
+		FASTWC_SETTING_MINI_CART_BUTTON_STYLES,
+		FASTWC_SETTING_CHECKOUT_BUTTON_STYLES,
+		FASTWC_SETTING_LOGIN_BUTTON_STYLES,
+		FASTWC_SETTING_HIDE_BUTTON_PRODUCTS,
+		FASTWC_SETTING_CHECKOUT_REDIRECT_PAGE,
+		FASTWC_SETTING_PDP_BUTTON_HOOK,
+		FASTWC_SETTING_PDP_BUTTON_HOOK_OTHER,
+	);
+
+	if ( in_array( $option, $stampable_options, true ) ) {
+		$fastwc_settings_timestamps = get_option( FASTWC_SETTINGS_TIMESTAMPS, array() );
+
+		$fastwc_settings_timestamps[ $option ] = time();
+
+		update_option( FASTWC_SETTINGS_TIMESTAMPS, $fastwc_settings_timestamps );
+	}
+}
+add_action( 'updated_option', 'fastwc_updated_option', 10, 3 );
+
 add_action( 'admin_menu', 'fastwc_admin_create_menu' );
 add_action( 'admin_init', 'fastwc_admin_setup_sections' );
 add_action( 'admin_init', 'fastwc_admin_setup_fields' );


### PR DESCRIPTION
# Description

Display a "Last modified" timestamp for the Fast settings.

# Testing instructions

1. Login to the [staging admin](https://fasttestdev.wpcomstaging.com/wp-admin).
2. Go to the [Fast settings "Styles" tab](https://fasttestdev.wpcomstaging.com/wp-admin/admin.php?page=fast&tab=fast_styles).
3. Make a change to any of the styles.
4. Save the change.
5. Verify that a "Last modified" timestamp appears.

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`

@ilkerulutas @brikr this is ready for review.