### PR TITLE
Update version number to 1.1.6 and add changelog

### DIFF
--- a/fast.php
+++ b/fast.php
@@ -5,7 +5,7 @@
  * Author: Fast
  * Author URI: https://fast.co
  * Description: Install the Checkout button that increases conversion, boosts sales and delights customers.
- * Version: 1.1.5
+ * Version: 1.1.6
  * License: GPLv2
  * License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  *
@@ -14,7 +14,7 @@
 
 define( 'FASTWC_PATH', plugin_dir_path( __FILE__ ) );
 define( 'FASTWC_URL', plugin_dir_url( __FILE__ ) );
-define( 'FASTWC_VERSION', '1.1.5' );
+define( 'FASTWC_VERSION', '1.1.6' );
 
 // WooCommerce version utilities.
 require_once FASTWC_PATH . 'includes/version.php';

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: fast, fast checkout, checkout, woocommerce, woocommerce payment, woocommer
 Requires at least: 5.1
 Tested up to: 5.8
 Requires PHP: 7.2
-Stable tag: 1.1.5
+Stable tag: 1.1.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
  
@@ -34,6 +34,14 @@ Fast replaces your current payment processor. You can see our fee schedule, simi
 
  
 == Changelog ==
+
+= 1.1.6 =
+
+* Link to the Fast settings page from the plugins page.
+* Redirect to the Fast settings page after activation.
+* Add a [changelog.txt](https://raw.githubusercontent.com/fast-af/fast-checkout-woocommerce/main/changelog.txt) file.
+* Add "Last updates" timestamps to some of the settings in the Fast settings page.
+* Add opt-in tool to track active installations
 
 = 1.1.5 =
 


### PR DESCRIPTION
# Description

Update the version number to 1.1.6 and update the changelog.

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`