### PR TITLE
Resolves PINT-716 - Get the shipping address from the order

### DIFF
--- a/includes/routes/class-shipping.php
+++ b/includes/routes/class-shipping.php
@@ -140,8 +140,8 @@ class Shipping extends Route {
 	 * @return mixed
 	 */
 	protected function update_customer_information( $params ) {
-		$shipping_param = ! empty( $params['shipping'] ) ? $params['shipping'] : array();
-		$shipping_param = wp_parse_args(
+		$shipping_param = ! empty( $params['shipping'] ) ? $params['shipping'] : $this->maybe_get_shipping_address_from_order( $params );
+		$shipping_param = \wp_parse_args(
 			$shipping_param,
 			array(
 				'country'   => '',
@@ -187,6 +187,31 @@ class Shipping extends Route {
 
 		// Return false for no error.
 		return false;
+	}
+
+	/**
+	 * Get the shipping address from the order if an order ID is passed in.
+	 *
+	 * @param array $params The request params.
+	 *
+	 * @return array
+	 */
+	protected function maybe_get_shipping_address_from_order( $params ) {
+		$order_id         = ! empty( $params['order_id'] ) ? $params['order_id'] : 0;
+		$shipping_address = array();
+
+		// If no order ID is passed in with the request, do nothing.
+		if ( ! empty( $order_id ) ) {
+			$order = \wc_get_order( $order_id );
+
+			// If there is no order object with the passed in order ID, do nothing.
+			if ( ! empty( $order ) && method_exists( $order, 'get_address' ) ) {
+				// Get shipping address from the order.
+				$shipping_address = $order->get_address( 'shipping' );
+			}
+		}
+
+		return $shipping_address;
 	}
 
 	/**


### PR DESCRIPTION
# Description

If no shipping address is passed to the shipping endpoint, but an order ID is passed, this update attempts to grab the shipping address from the order.

# Testing instructions

1. Using Postman, make a call to the shipping endpoint on staging with an empty shipping address, valid line items, and a valid order ID.
2. Verify that shipping options are returned with the shipping address from the order that was included in the call to the endpoint.

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`