### PR TITLE
Resolves PINT-746 - Remove check for product webhooks

### DIFF
--- a/includes/webhooks.php
+++ b/includes/webhooks.php
@@ -18,9 +18,6 @@ function fastwc_get_fast_webhook_topics() {
 		'order.deleted',
 		'order.updated',
 		'order.created',
-		'product.deleted',
-		'product.updated',
-		'product.created',
 	);
 }
 
@@ -272,7 +269,7 @@ function fastwc_woocommerce_has_fast_webhooks() {
 	$webhooks       = fastwc_get_fast_webhooks();
 	$webhooks_count = ! empty( $webhooks ) ? count( $webhooks ) : 0;
 
-	if ( 6 <= $webhooks_count ) {
+	if ( 3 <= $webhooks_count ) {
 		return true;
 	}
 


### PR DESCRIPTION
# Description

The webhook check is showing an admin notice when the product webhooks are missing. This update removes the check for product webhooks to avoid having the admin notice because the product webhooks are not being installed during onboarding and are not currently necessary.

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`