### PR TITLE
Resolves PINT-740 - Add tools mitigate plugin conflicts

### DIFF
--- a/fast.php
+++ b/fast.php
@@ -43,6 +43,8 @@ if ( fastwc_woocommerce_is_active() ) {
 	require_once FASTWC_PATH . 'includes/blocks.php';
 	// Add Fast failed/disabled webhook handler.
 	require_once FASTWC_PATH . 'includes/webhooks.php';
+	// Add tools to support third-party plugins.
+	require_once FASTWC_PATH . 'includes/third-party.php';
 	// Add Freemius integration.
 	require_once FASTWC_PATH . 'includes/class-freemius.php';
 }

--- a/includes/admin/constants.php
+++ b/includes/admin/constants.php
@@ -29,6 +29,7 @@ define( 'FASTWC_SETTING_CHECKOUT_REDIRECT_PAGE', 'fastwc_checkout_redirect_page'
 define( 'FASTWC_SETTING_PDP_BUTTON_HOOK', 'fast_pdp_button_hook' );
 define( 'FASTWC_DEFAULT_PDP_BUTTON_HOOK', 'woocommerce_after_add_to_cart_quantity' );
 define( 'FASTWC_SETTING_PDP_BUTTON_HOOK_OTHER', 'fast_pdp_button_hook_other' );
+define( 'FASTWC_SETTING_PLUGIN_DO_INIT_FORMAT', 'fastwc_do_init_%s' );
 define( 'FASTWC_JWKS_URL', 'https://api.fast.co/v1/oauth2/jwks' );
 define( 'FASTWC_JS_URL', 'https://js.fast.co/fast-woocommerce.js' );
 define( 'FASTWC_ONBOARDING_URL', 'https://fast.co/business' );

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -151,13 +151,23 @@ function fastwc_should_show_advanced_settings() {
  * @return array
  */
 function fastwc_get_settings_tabs() {
-	return array(
-		'fast_app_info'  => __( 'App Info', 'fast' ),
-		'fast_styles'    => __( 'Styles', 'fast' ),
-		'fast_options'   => __( 'Options', 'fast' ),
-		'fast_test_mode' => __( 'Test Mode', 'fast' ),
-		'fast_support'   => __( 'Support', 'fast' ),
-		'fast_status'    => __( 'Status', 'fast' ),
+	/**
+	 * Filter the list of settins tabs.
+	 *
+	 * @param array $settings_tabs The settings tabs.
+	 *
+	 * @return array
+	 */
+	return apply_filters(
+		'fastwc_settings_tabs',
+		array(
+			'fast_app_info'  => __( 'App Info', 'fast' ),
+			'fast_styles'    => __( 'Styles', 'fast' ),
+			'fast_options'   => __( 'Options', 'fast' ),
+			'fast_test_mode' => __( 'Test Mode', 'fast' ),
+			'fast_support'   => __( 'Support', 'fast' ),
+			'fast_status'    => __( 'Status', 'fast' ),
+		)
 	);
 }
 

--- a/includes/third-party.php
+++ b/includes/third-party.php
@@ -24,7 +24,7 @@ function fastwc_initialize_third_party_plugin_support() {
 	$fastwc_third_party_plugins = apply_filters(
 		'fastwc_third_party_plugin_classes',
 		array(
-			'FastWC\Third_Party\WooCommerce_Tiered_Pricing_Table'
+			'FastWC\Third_Party\WooCommerce_Tiered_Pricing_Table',
 		)
 	);
 

--- a/includes/third-party.php
+++ b/includes/third-party.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Tools to mitigate conflicts with third-party plugins that prevent the Fast Checkout experience from fully working properly.
+ *
+ * @package Fast
+ */
+
+// Load the base third-party plugin class.
+require_once FASTWC_PATH . 'includes/third-party/class-plugin.php';
+// Load the WooCommerce Tiered Pricing Table class.
+require_once FASTWC_PATH . 'includes/third-party/class-woocommerce-tiered-pricing-table.php';
+
+/**
+ * Initialize the third-party plugin tools.
+ */
+function fastwc_initialize_third_party_plugin_support() {
+	/**
+	 * Filter the list of third-party plugins.
+	 *
+	 * @param array $fastwc_third_party_plugins The list of third-party plugins.
+	 *
+	 * @return array
+	 */
+	$fastwc_third_party_plugins = apply_filters(
+		'fastwc_third_party_plugin_classes',
+		array(
+			'FastWC\Third_Party\WooCommerce_Tiered_Pricing_Table'
+		)
+	);
+
+	foreach ( $fastwc_third_party_plugins as $fastwc_third_party_plugin ) {
+		if (
+			class_exists( $fastwc_third_party_plugin ) &&
+			method_exists( $fastwc_third_party_plugin, 'get_instance' )
+		) {
+			$fastwc_third_party_plugin::get_instance();
+		}
+	}
+}
+fastwc_initialize_third_party_plugin_support();

--- a/includes/third-party/class-plugin.php
+++ b/includes/third-party/class-plugin.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * Fast base third-party plugin class.
+ *
+ * @package Fast
+ */
+
+namespace FastWC\Third_Party;
+
+/**
+ * Fast base third-party plugin class.
+ */
+abstract class Plugin {
+
+	/**
+	 * Instance of the plugin class.
+	 *
+	 * @var FastWC\Third_Party\Plugin
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Plugin slug.
+	 *
+	 * @var string
+	 */
+	protected $slug = '';
+
+	/**
+	 * Plugin status.
+	 *
+	 * @var string
+	 */
+	protected $status = '';
+
+	/**
+	 * Settings section name.
+	 *
+	 * @var string
+	 */
+	protected $section_name = 'fast_third_party';
+
+	/**
+	 * Get an instance of the plugin and initialize it.
+	 */
+	public static function get_instance() {
+		if ( null === static::$instance ) {
+			static::$instance = new static();
+		}
+
+		if ( static::$instance->is_active() ) {
+			\add_action( 'admin_init', array( static::$instance, 'maybe_add_setting' ) );
+
+			$setting_name = static::$instance->get_setting_name();
+
+			$do_init = boolval(
+				\get_option(
+					$setting_name,
+					true
+				)
+			);
+
+			$do_init = boolval(
+				/**
+				 * Flag to activate or deactivate the plugin initialization.
+				 *
+				 * @param bool $do_init The initial value of the flag.
+				 *
+				 * @return bool
+				 */
+				\apply_filters(
+					$setting_name,
+					$do_init
+				)
+			);
+
+			if ( $do_init ) {
+				static::$instance->init();
+			}
+		}
+	}
+
+	/**
+	 * Initialize the plugin.
+	 */
+	abstract protected function init();
+
+	/**
+	 * Get the setting name.
+	 *
+	 * @return string
+	 */
+	protected function get_setting_name() {
+		return sprintf(
+			FASTWC_SETTING_PLUGIN_DO_INIT_FORMAT,
+			str_replace( array( '/', '.' ), '_', $this->slug )
+		);
+	}
+
+	/**
+	 * Maybe add the settings section.
+	 */
+	protected function maybe_add_settings_section() {
+		global $wp_settings_sections;
+
+		if ( empty( $wp_settings_sections[ $this->section_name ][ $this->section_name ] ) ) {
+			\add_settings_section( $this->section_name, '', false, $this->section_name );
+
+			\add_filter(
+				'fastwc_settings_tabs',
+				/**
+				 * Update the list of settings tabs.
+				 *
+				 * @param array $settings_tabs The list of settings tabs.
+				 *
+				 * @return array
+				 */
+				function( $settings_tabs ) {
+					$settings_tabs[ $this->section_name ] = \__( 'Third Party Plugins', 'fast' );
+
+					return $settings_tabs;
+				}
+			);
+		}
+	}
+
+	/**
+	 * Get the setting title.
+	 *
+	 * @return string
+	 */
+	protected function get_setting_title() {
+		return '';
+	}
+
+	/**
+	 * Get the setting description.
+	 *
+	 * @return string
+	 */
+	protected function get_setting_description() {
+		return '';
+	}
+
+	/**
+	 * Callback for rendering the setting.
+	 */
+	public function setting_callback() {
+		$setting_name  = $this->get_setting_name();
+		$not_set_value = 'not set';
+		$setting_value = \get_option( $setting_name, $not_set_value );
+
+		if ( $not_set_value === $setting_value ) {
+			$setting_value = '1';
+			update_option( $setting_name, $setting_value );
+		}
+
+		\fastwc_settings_field_checkbox(
+			array(
+				'name'        => $setting_name,
+				'current'     => $setting_value,
+				'label'       => $this->get_setting_title(),
+				'description' => $this->get_setting_description(),
+			)
+		);
+	}
+
+
+	/**
+	 * If the plugin is active, add a setting to activate/deactivate the plugin support object.
+	 *
+	 * @return bool
+	 */
+	public function maybe_add_setting() {
+		if ( $this->is_active() ) {
+			$setting_name = $this->get_setting_name();
+
+			$this->maybe_add_settings_section();
+			\register_setting( $this->section_name, $setting_name );
+			// add_settings_field( string $id, string $title, callable $callback, string $page, string $section = 'default', array $args = array() )
+			\add_settings_field( $setting_name, $this->get_setting_title(), array( $this, 'setting_callback' ), $this->section_name, $this->section_name );
+
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check to see if the plugin is active.
+	 *
+	 * @return bool
+	 */
+	protected function is_active() {
+		$is_active = false;
+
+		if ( empty( $this->status ) ) {
+			if ( ! function_exists( 'is_plugin_active' ) ) {
+				require_once ABSPATH . '/wp-admin/includes/plugin.php';
+			}
+
+			$is_active = \is_plugin_active( $this->slug );
+
+			// Store the status to avoid having to call `is_plugin_active` again.
+			$this->status = $is_active ? 'active' : 'inactive';
+		} else {
+			$is_active = ( 'active' === $this->status );
+		}
+
+		return $is_active;
+	}
+
+}

--- a/includes/third-party/class-plugin.php
+++ b/includes/third-party/class-plugin.php
@@ -129,18 +129,14 @@ abstract class Plugin {
 	 *
 	 * @return string
 	 */
-	protected function get_setting_title() {
-		return '';
-	}
+	abstract protected function get_setting_title();
 
 	/**
 	 * Get the setting description.
 	 *
 	 * @return string
 	 */
-	protected function get_setting_description() {
-		return '';
-	}
+	abstract protected function get_setting_description();
 
 	/**
 	 * Callback for rendering the setting.

--- a/includes/third-party/class-woocommerce-tiered-pricing-table.php
+++ b/includes/third-party/class-woocommerce-tiered-pricing-table.php
@@ -61,7 +61,7 @@ class WooCommerce_Tiered_Pricing_Table extends Plugin {
 			return;
 		}
 
-		if ( $item instanceof WC_Order_Item_Product ) {
+		if ( $item instanceof \WC_Order_Item_Product ) {
 			$product_id = $item->get_variation_id() ? $item->get_variation_id() : $item->get_product_id();
 			$qty        = $item->get_quantity();
 			$new_price   = \TierPricingTable\PriceManager::getPriceByRules( $qty, $product_id );

--- a/includes/third-party/class-woocommerce-tiered-pricing-table.php
+++ b/includes/third-party/class-woocommerce-tiered-pricing-table.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Fast third-party plugin class for WooCommerce Tiered Pricing Table.
+ *
+ * @see https://en-gb.wordpress.org/plugins/tier-pricing-table/
+ *
+ * @package Fast
+ */
+
+namespace FastWC\Third_Party;
+
+/**
+ * Fast base third-party plugin class.
+ */
+class WooCommerce_Tiered_Pricing_Table extends Plugin {
+
+	/**
+	 * Plugin slug.
+	 *
+	 * @var string
+	 */
+	protected $slug = 'tier-pricing-table/tier-pricing-table.php';
+
+	/**
+	 * Initialize the plugin.
+	 */
+	protected function init() {
+		\add_action( 'woocommerce_rest_set_order_item', array( $this, 'woocommerce_rest_set_order_item' ), 10, 2 );
+	}
+
+	/**
+	 * Get the setting title.
+	 *
+	 * @return string
+	 */
+	protected function get_setting_title() {
+		return \__( 'WooCommerce Tiered Pricing Table', 'fast' );
+	}
+
+	/**
+	 * Get the setting description.
+	 *
+	 * @return string
+	 */
+	protected function get_setting_description() {
+		return \__( 'Activate tools to add support for the WooCommerce Tiered Pricing Table plugin', 'fast' );
+	}
+
+	/**
+	 * Update the item price with the tiered price based on quantity when order created through REST API.
+	 * Mitigates a conflict with the WooCommerce Tiered Price Table plugin.
+	 *
+	 * @see https://en-gb.wordpress.org/plugins/tier-pricing-table/
+	 *
+	 * @param mixed $item   The order item.
+	 * @param array $posted The item provided in the request body.
+	 */
+	public function woocommerce_rest_set_order_item( $item, $posted ) {
+		// Do nothing if this class doesn't exist. If it is not there, that means the plugin is not installed.
+		if ( ! class_exists( '\TierPricingTable\PriceManager') ) {
+			return;
+		}
+
+		if ( $item instanceof WC_Order_Item_Product ) {
+			$product_id = $item->get_variation_id() ? $item->get_variation_id() : $item->get_product_id();
+			$qty        = $item->get_quantity();
+			$new_price   = \TierPricingTable\PriceManager::getPriceByRules( $qty, $product_id );
+
+			$new_price = $new_price ? $new_price : $item->get_product()->get_price();
+
+			$item->get_product()->set_price( $new_price );
+			$item->set_subtotal( $new_price * $qty );
+			$item->set_total( $new_price * $qty );
+
+			$item->save();
+		}
+	}
+}

--- a/templates/admin/tabs/fast-third-party.php
+++ b/templates/admin/tabs/fast-third-party.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Fast settings Third-Party Plugins tab template.
+ *
+ * @package Fast
+ */
+
+?>
+<form method="post" action="options.php">
+	<?php
+	settings_fields( 'fast_third_party' );
+	do_settings_sections( 'fast_third_party' );
+	submit_button();
+	?>
+</form>


### PR DESCRIPTION
# Description

Add a standard way to add code to mitigate conflicts with third-party plugins.

# Testing instructions

## Verify that the tab is displayed when the WooCommerce Tiered Pricing Table plugin is active

1. Login to the staging admin.
2. Go to the Plugins page.
3. Deactivate the WooCommerce Tiered Pricing Table plugin.
4. Go to the Fast settings page.
5. Verify that the "Third-Party Plugins" tab is not there.
6. Go back to the Plugins page.
7. Activate the WooCommerce Tiered Pricing Table plugin.
8. Go back to the Fast settings page.
9. Verify that the "Third-Party Plugins" tab is there.

## Verify that the mitigation works.

1. Go to the Fast settings page.
2. Click on the "Third-Party Plugins" tab.
3. Make sure that that checkbox is checked by "WooCommerce Tiered Pricing Table"
4. Go to the front end of the site.
5. Click on the Album product.
6. Set the quantity to 10
7. Click the Fast Checkout button
8. Verify that the $5 per item price is reflected in the checkout window.
9. Go back to the Fast settings page.
10. Click on the "Third-Party Plugins" tab.
11. Uncheck the box by "WooCommerce Tiered Pricing Table"
12. Go back to the front end of the site.
13. Click on the Album product.
14. Set the quantity to 10.
15. Click the Fast Checkout button
16. Verify that the original price is used and not the $5 price.

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`