### PR TITLE
Enqueue Fast admin scripts only on Fast settings pages

### DIFF
--- a/includes/assets.php
+++ b/includes/assets.php
@@ -19,6 +19,13 @@ add_action( 'login_enqueue_scripts', 'fastwc_enqueue_script' );
  * Enqueue admin assets.
  */
 function fastwc_admin_enqueue_scripts() {
+	// Only load the Fast admin scripts on the Fast settings pages.
+	$current_screen = get_current_screen();
+
+	if ( ! empty( $current_screen ) && isset( $current_screen->id ) && 'toplevel_page_fast' !== $current_screen->id ) {
+		return;
+	}
+
 	/**
 	 * Load the Select2 library.
 	 *
@@ -49,11 +56,6 @@ function fastwc_admin_enqueue_scripts() {
 		true
 	);
 
-	$current_screen = get_current_screen();
-
-	if ( ! empty( $current_screen ) && isset( $current_screen->id ) && 'toplevel_page_fast' !== $current_screen->id ) {
-		return;
-	}
 	wp_enqueue_style(
 		'fast-admin-css',
 		FASTWC_URL . 'assets/dist/styles.css',


### PR DESCRIPTION
# Description

@seldyyy reported an issue where the Fast admin scripts, specifically the Select2 plugin for jQuery, were interfering with other plugin scripts. This update makes it so that the Fast admin scripts only load on the Fast settings pages.

# Testing instructions

1. Login to the staging admin.
2. Verify that the Fast scripts are only loaded on the Fast settings pages.

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`