### PR TITLE
PINT-799 - Add option to hide the WooCommerce cart checkout buttons

### DIFF
--- a/includes/admin/constants.php
+++ b/includes/admin/constants.php
@@ -29,6 +29,7 @@ define( 'FASTWC_SETTING_CHECKOUT_REDIRECT_PAGE', 'fastwc_checkout_redirect_page'
 define( 'FASTWC_SETTING_PDP_BUTTON_HOOK', 'fast_pdp_button_hook' );
 define( 'FASTWC_DEFAULT_PDP_BUTTON_HOOK', 'woocommerce_after_add_to_cart_quantity' );
 define( 'FASTWC_SETTING_PDP_BUTTON_HOOK_OTHER', 'fast_pdp_button_hook_other' );
+define( 'FASTWC_SETTING_HIDE_REGULAR_CHECKOUT_BUTTONS', 'fastwc_hide_regular_checkout_buttons' );
 define( 'FASTWC_SETTING_PLUGIN_DO_INIT_FORMAT', 'fastwc_do_init_%s' );
 define( 'FASTWC_JWKS_URL', 'https://api.fast.co/v1/oauth2/jwks' );
 define( 'FASTWC_JS_URL', 'https://js.fast.co/fast-woocommerce.js' );

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -212,6 +212,7 @@ function fastwc_admin_setup_sections() {
 	register_setting( $section_name, FASTWC_SETTING_PDP_BUTTON_HOOK_OTHER );
 	register_setting( $section_name, FASTWC_SETTING_HIDE_BUTTON_PRODUCTS );
 	register_setting( $section_name, FASTWC_SETTING_CHECKOUT_REDIRECT_PAGE );
+	register_setting( $section_name, FASTWC_SETTING_HIDE_REGULAR_CHECKOUT_BUTTONS );
 	register_setting( $section_name, FASTWC_SETTING_SHOW_LOGIN_BUTTON_FOOTER );
 
 	$section_name = 'fast_test_mode';
@@ -254,6 +255,7 @@ function fastwc_admin_setup_fields() {
 	add_settings_field( FASTWC_SETTING_PDP_BUTTON_HOOK_OTHER, __( 'Enter Alternate Product Button Location', 'fast' ), 'fastwc_pdp_button_hook_other', $settings_section, $settings_section );
 	add_settings_field( FASTWC_SETTING_HIDE_BUTTON_PRODUCTS, __( 'Hide Buttons for these Products', 'fast' ), 'fastwc_hide_button_products', $settings_section, $settings_section );
 	add_settings_field( FASTWC_SETTING_CHECKOUT_REDIRECT_PAGE, __( 'Checkout Redirect Page', 'fast' ), 'fastwc_checkout_redirect_page', $settings_section, $settings_section );
+	add_settings_field( FASTWC_SETTING_HIDE_REGULAR_CHECKOUT_BUTTONS, __( 'Hide WooCommerce Checkout Buttons on Cart', 'fast' ), 'fastwc_hide_regular_checkout_buttons', $settings_section, $settings_section );
 	add_settings_field( FASTWC_SETTING_SHOW_LOGIN_BUTTON_FOOTER, __( 'Display Login in Footer', 'fast' ), 'fastwc_show_login_button_footer', $settings_section, $settings_section );
 
 	// Test Mode settings.
@@ -511,6 +513,22 @@ function fastwc_checkout_redirect_page() {
 			'description' => __( 'Select a page to redirect to after a successful cart checkout. Leave blank to redirect to the cart.', 'fast' ),
 			'nonce'       => 'search-pages',
 			'multiple'    => false,
+		)
+	);
+}
+
+/**
+ * Hides the regular checkout buttons.
+ */
+function fastwc_hide_regular_checkout_buttons() {
+	$fastwc_hide_regular_checkout_buttons = get_option( FASTWC_SETTING_HIDE_REGULAR_CHECKOUT_BUTTONS, '0' );
+
+	fastwc_settings_field_checkbox(
+		array(
+			'name'        => FASTWC_SETTING_HIDE_REGULAR_CHECKOUT_BUTTONS,
+			'current'     => $fastwc_hide_regular_checkout_buttons,
+			'label'       => __( 'Hide WooCommerce Checkout Buttons on Cart', 'fast' ),
+			'description' => __( 'Hide the standard WooCommerce "Proceed to Checkout" buttons on the cart page and the mini cart widget.', 'fast' ),
 		)
 	);
 }

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -223,3 +223,22 @@ function fastwc_maybe_clear_cart_and_redirect() {
 	}
 }
 add_action( 'init', 'fastwc_maybe_clear_cart_and_redirect' );
+
+/**
+ * Maybe hide the regular "Proceed to Checkout" buttons.
+ */
+function fastwc_maybe_hide_proceed_to_checkout_buttons() {
+
+	// Do nothing in the admin.
+	if ( is_admin() ) {
+		return;
+	}
+
+	$hide_regular_checkout_buttons = get_option( FASTWC_SETTING_HIDE_REGULAR_CHECKOUT_BUTTONS, false );
+
+	if ( $hide_regular_checkout_buttons ) {
+		remove_action( 'woocommerce_proceed_to_checkout', 'woocommerce_button_proceed_to_checkout', 20 );
+		remove_action( 'woocommerce_widget_shopping_cart_buttons', 'woocommerce_widget_shopping_cart_button_view_cart', 10 );
+	}
+}
+add_action( 'init', 'fastwc_maybe_hide_proceed_to_checkout_buttons' );

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -238,7 +238,7 @@ function fastwc_maybe_hide_proceed_to_checkout_buttons() {
 
 	if ( $hide_regular_checkout_buttons ) {
 		remove_action( 'woocommerce_proceed_to_checkout', 'woocommerce_button_proceed_to_checkout', 20 );
-		remove_action( 'woocommerce_widget_shopping_cart_buttons', 'woocommerce_widget_shopping_cart_button_view_cart', 10 );
+		remove_action( 'woocommerce_widget_shopping_cart_buttons', 'woocommerce_widget_shopping_cart_proceed_to_checkout', 20 );
 	}
 }
 add_action( 'init', 'fastwc_maybe_hide_proceed_to_checkout_buttons' );


### PR DESCRIPTION
# Description

Add an option to hide the standard WooCommerce checkout buttons in the mini cart widget and on the cart page.

# Testing instructions

1. Login to staging
2. Go to the Fast settings page and click on the Options tab.
3. Check the option to "Hide WooCommerce Checkout Buttons on Cart"
4. Verify that the standard WooCommerce checkout buttons are not displayed on the mini cart widget or the cart page.

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`