### PR TITLE
PINT-835 - Only apply coupons if different

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -306,6 +306,8 @@ function fastwc_check_request_coupon_lines( $request, $order ) {
 		return;
 	}
 
+	$discounts = new WC_Discounts( $order );
+
 	$current_order_coupons      = array_values( $order->get_coupons() );
 	$current_order_coupon_codes = array_map(
 		function( $coupon ) {
@@ -327,5 +329,9 @@ function fastwc_check_request_coupon_lines( $request, $order ) {
 		}
 	}
 
-	$request['coupon_lines'] = $new_coupon_lines;
+	if ( empty( $new_coupon_lines ) ) {
+		unset( $request['coupon_lines'] );
+	} else {
+		$request['coupon_lines'] = $new_coupon_lines;
+	}
 }

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -297,7 +297,7 @@ add_action( 'init', 'fastwc_maybe_hide_proceed_to_checkout_buttons' );
  * @param string    $used_by   The customer who used the coupon.
  */
 function fastwc_log_coupon_usage_on_increase( $coupon, $new_count, $used_by ) {
-	fastwc_log_info( 'Coupon (increase): ' . print_r( $coupon, true ) );
+	fastwc_log_info( 'Coupon (increase): ' . $coupon->get_code() );
 	fastwc_log_info( 'New coupon usage count (increase): ' . $new_count );
 	fastwc_log_info( 'Coupon used by (increase): ' . $used_by );
 }
@@ -311,7 +311,7 @@ add_action( 'woocommerce_increase_coupon_usage_count', 'fastwc_log_coupon_usage_
  * @param string    $used_by   The customer who used the coupon.
  */
 function fastwc_log_coupon_usage_on_decrease( $coupon, $new_count, $used_by ) {
-	fastwc_log_info( 'Coupon (decrease): ' . print_r( $coupon, true ) );
+	fastwc_log_info( 'Coupon (decrease): ' . $coupon->get_code() );
 	fastwc_log_info( 'New coupon usage count (decrease): ' . $new_count );
 	fastwc_log_info( 'Coupon used by (decrease): ' . $used_by );
 }

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -288,3 +288,31 @@ function fastwc_maybe_hide_proceed_to_checkout_buttons() {
 	}
 }
 add_action( 'init', 'fastwc_maybe_hide_proceed_to_checkout_buttons' );
+
+/**
+ * Log coupon usage on increase usage count.
+ *
+ * @param WC_Coupon $coupon    The coupon object.
+ * @param int       $new_count The new usage count.
+ * @param string    $used_by   The customer who used the coupon.
+ */
+function fastwc_log_coupon_usage_on_increase( $coupon, $new_count, $used_by ) {
+	fastwc_log_info( 'Coupon (increase): ' . print_r( $coupon, true ) );
+	fastwc_log_info( 'New coupon usage count (increase): ' . $new_count );
+	fastwc_log_info( 'Coupon used by (increase): ' . $used_by );
+}
+add_action( 'woocommerce_increase_coupon_usage_count', 'fastwc_log_coupon_usage_on_increase', 10, 3 );
+
+/**
+ * Log coupon usage on decrease usage count.
+ *
+ * @param WC_Coupon $coupon    The coupon object.
+ * @param int       $new_count The new usage count.
+ * @param string    $used_by   The customer who used the coupon.
+ */
+function fastwc_log_coupon_usage_on_decrease( $coupon, $new_count, $used_by ) {
+	fastwc_log_info( 'Coupon (decrease): ' . print_r( $coupon, true ) );
+	fastwc_log_info( 'New coupon usage count (decrease): ' . $new_count );
+	fastwc_log_info( 'Coupon used by (decrease): ' . $used_by );
+}
+add_action( 'woocommerce_decrease_coupon_usage_count', 'fastwc_log_coupon_usage_on_decrease', 10, 3 );

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -122,14 +122,14 @@ add_action( 'woocommerce_before_checkout_form', 'fastwc_woocommerce_before_check
  */
 function fastwc_woocommerce_rest_pre_insert_shop_order_object( $order, $request ) {
 
-	fastwc_log_debug( 'Request object: ' . print_r( $request, true ) );
+	fastwc_log_debug( 'Request object: ' . print_r( $request, true ) ); // phpcs:ignore
 
 	fastwc_log_debug( 'fastwc_woocommerce_rest_pre_insert_shop_order_object ' . print_r( $order, true ) ); // phpcs:ignore
 
 	// Remove coupon lines from request if the coupon has already been applied to the order.
 	fastwc_check_request_coupon_lines( $request, $order );
 
-	fastwc_log_debug( 'Request object after coupon lines check: ' . print_r( $request, true ) );
+	fastwc_log_debug( 'Request object after coupon lines check: ' . print_r( $request, true ) ); // phpcs:ignore
 
 	// For order updates with a coupon line item, make sure there is a cart object.
 	if (

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -308,7 +308,11 @@ function fastwc_check_request_coupon_lines( $request, $order ) {
 
 	$discounts = new WC_Discounts( $order );
 
-	$current_order_coupons      = array_values( $order->get_coupons() );
+	$current_order_coupons = array_values( $order->get_coupons() );
+	if ( empty( $current_order_coupons ) ) {
+		return;
+	}
+
 	$current_order_coupon_codes = array_map(
 		function( $coupon ) {
 			return $coupon->get_code();
@@ -331,6 +335,7 @@ function fastwc_check_request_coupon_lines( $request, $order ) {
 
 	if ( empty( $new_coupon_lines ) ) {
 		unset( $request['coupon_lines'] );
+		$order->recalculate_coupons();
 	} else {
 		$request['coupon_lines'] = $new_coupon_lines;
 	}

--- a/includes/routes/class-shipping.php
+++ b/includes/routes/class-shipping.php
@@ -182,8 +182,6 @@ class Shipping extends Route {
 
 		// See if we need to calculate anything.
 		if ( ! \WC()->cart->needs_shipping() ) {
-            \fastwc_log_debug( 'Fast Shipping Endpiont Request: ' . print_r( $this->request, true ) );
-            \fastwc_log_debug( 'Fast Shipping Endpiont Cart: ' . print_r( \WC()->cart, true ) );
 			return new \WP_Error( 'shipping_methods_error', 'no shipping methods available for product and address', array( 'status' => 400 ) );
 		}
 

--- a/includes/routes/class-shipping.php
+++ b/includes/routes/class-shipping.php
@@ -182,6 +182,8 @@ class Shipping extends Route {
 
 		// See if we need to calculate anything.
 		if ( ! \WC()->cart->needs_shipping() ) {
+            \fastwc_log_debug( 'Fast Shipping Endpiont Request: ' . print_r( $this->request, true ) );
+            \fastwc_log_debug( 'Fast Shipping Endpiont Cart: ' . print_r( \WC()->cart, true ) );
 			return new \WP_Error( 'shipping_methods_error', 'no shipping methods available for product and address', array( 'status' => 400 ) );
 		}
 


### PR DESCRIPTION
# Description

An issue was discovered where if a coupon was limited to a single use per customer, it does not work if the order is changed via the Fast checkout window because the coupon usage count in WooCommerce was getting incremented more than once. This resulted in an error because the coupon usage limit had been reached for that particular coupon.

This update prevents the coupon from being re-applied to the order if/when it gets submitted multiple times with REST API requests, which prevents the usage count from falsely increasing beyond the usage limit.

# Testing instructions

1. Login to staging.
2. Create a coupon that is limited to a single use per user.
3. Purchase a product with Fast Checkout.
4. Apply the coupon via the Fast checkout window.
5. Edit the order in the Fast checkout window by changing the quantity.
6. Verify that the coupon is applied to the order in Fast and to the order in WooCommerce.
7. Verify that there are no usage limit errors.

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`