### PR TITLE
PINT-890 - Update order redirect functionality

### DIFF
--- a/includes/admin/constants.php
+++ b/includes/admin/constants.php
@@ -27,6 +27,8 @@ define( 'FASTWC_SETTING_LOGIN_FOOTER_NOT_SET', 'fast login in footer not set' );
 define( 'FASTWC_SETTING_DISABLE_MULTICURRENCY', 'fastwc_disable_multicurrency' );
 define( 'FASTWC_SETTING_HIDE_BUTTON_PRODUCTS', 'fast_hide_button_products' );
 define( 'FASTWC_SETTING_CHECKOUT_REDIRECT_PAGE', 'fastwc_checkout_redirect_page' );
+define( 'FASTWC_SETTING_REDIRECT_AFTER_PDP', 'fastwc_redirect_after_pdp_order' );
+define( 'FASTWC_SETTING_CLEAR_CART_AFTER_PDP', 'fastwc_clear_cart_after_pdp' );
 define( 'FASTWC_SETTING_PDP_BUTTON_HOOK', 'fast_pdp_button_hook' );
 define( 'FASTWC_DEFAULT_PDP_BUTTON_HOOK', 'woocommerce_after_add_to_cart_quantity' );
 define( 'FASTWC_SETTING_PDP_BUTTON_HOOK_OTHER', 'fast_pdp_button_hook_other' );

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -213,6 +213,8 @@ function fastwc_admin_setup_sections() {
 	register_setting( $section_name, FASTWC_SETTING_PDP_BUTTON_HOOK_OTHER );
 	register_setting( $section_name, FASTWC_SETTING_HIDE_BUTTON_PRODUCTS );
 	register_setting( $section_name, FASTWC_SETTING_CHECKOUT_REDIRECT_PAGE );
+	register_setting( $section_name, FASTWC_SETTING_REDIRECT_AFTER_PDP );
+	register_setting( $section_name, FASTWC_SETTING_CLEAR_CART_AFTER_PDP );
 	register_setting( $section_name, FASTWC_SETTING_HIDE_REGULAR_CHECKOUT_BUTTONS );
 	register_setting( $section_name, FASTWC_SETTING_SHOW_LOGIN_BUTTON_FOOTER );
 
@@ -257,6 +259,8 @@ function fastwc_admin_setup_fields() {
 	add_settings_field( FASTWC_SETTING_PDP_BUTTON_HOOK_OTHER, __( 'Enter Alternate Product Button Location', 'fast' ), 'fastwc_pdp_button_hook_other', $settings_section, $settings_section );
 	add_settings_field( FASTWC_SETTING_HIDE_BUTTON_PRODUCTS, __( 'Hide Buttons for these Products', 'fast' ), 'fastwc_hide_button_products', $settings_section, $settings_section );
 	add_settings_field( FASTWC_SETTING_CHECKOUT_REDIRECT_PAGE, __( 'Checkout Redirect Page', 'fast' ), 'fastwc_checkout_redirect_page', $settings_section, $settings_section );
+	add_settings_field( FASTWC_SETTING_REDIRECT_AFTER_PDP, __( 'Redirect to a custom page after a PDP order', 'fast' ), 'fastwc_redirect_after_pdp_order', $settings_section, $settings_section );
+	add_settings_field( FASTWC_SETTING_CLEAR_CART_AFTER_PDP, __( 'Clear the cart after a PDP order', 'fast' ), 'fastwc_clear_cart_after_pdp_order', $settings_section, $settings_section );
 	add_settings_field( FASTWC_SETTING_HIDE_REGULAR_CHECKOUT_BUTTONS, __( 'Hide WooCommerce Checkout Buttons on Cart', 'fast' ), 'fastwc_hide_regular_checkout_buttons', $settings_section, $settings_section );
 	add_settings_field( FASTWC_SETTING_SHOW_LOGIN_BUTTON_FOOTER, __( 'Display Login in Footer', 'fast' ), 'fastwc_show_login_button_footer', $settings_section, $settings_section );
 
@@ -516,6 +520,38 @@ function fastwc_checkout_redirect_page() {
 			'description' => __( 'Select a page to redirect to after a successful cart checkout. Leave blank to redirect to the cart.', 'fast' ),
 			'nonce'       => 'search-pages',
 			'multiple'    => false,
+		)
+	);
+}
+
+/**
+ * Redirect the user after checkout.
+ */
+function fastwc_redirect_after_pdp_order() {
+	$fastwc_redirect_after_pdp_order = get_option( FASTWC_SETTING_REDIRECT_AFTER_PDP, '0' );
+
+	fastwc_settings_field_checkbox(
+		array(
+			'name'        => FASTWC_SETTING_REDIRECT_AFTER_PDP,
+			'current'     => $fastwc_redirect_after_pdp_order,
+			'label'       => __( 'Redirect the customer after a PDP order.', 'fast' ),
+			'description' => __( 'Check this box to redirect the customer after they complete the PDP order.', 'fast' ),
+		)
+	);
+}
+
+/**
+ * Redirect the user after checkout.
+ */
+function fastwc_clear_cart_after_pdp_order() {
+	$fastwc_clear_cart_after_pdp_order = get_option( FASTWC_SETTING_CLEAR_CART_AFTER_PDP, '0' );
+
+	fastwc_settings_field_checkbox(
+		array(
+			'name'        => FASTWC_SETTING_CLEAR_CART_AFTER_PDP,
+			'current'     => $fastwc_clear_cart_after_pdp_order,
+			'label'       => __( 'Clear the cart after a PDP order.', 'fast' ),
+			'description' => __( 'Check this box to clear the cart after the customer complete the PDP order.', 'fast' ),
 		)
 	);
 }

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -541,7 +541,7 @@ function fastwc_redirect_after_pdp_order() {
 }
 
 /**
- * Redirect the user after checkout.
+ * Clear the cart after checkout.
  */
 function fastwc_clear_cart_after_pdp_order() {
 	$fastwc_clear_cart_after_pdp_order = get_option( FASTWC_SETTING_CLEAR_CART_AFTER_PDP, '0' );

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -251,14 +251,14 @@ add_action( 'woocommerce_order_status_trash_to_on-hold', 'fastwc_order_status_tr
  */
 function fastwc_maybe_clear_cart_and_redirect() {
 	// Get the order ID from the `fast_order_created` query parameter in the URL, or set it to false.
-	$fast_order_id = isset( $_GET['fast_order_created'] ) ? sanitize_text_field( $_GET['fast_order_created'] ) : false; // phpcs:ignore
+	$order_id = isset( $_GET['fast_order_created'] ) ? sanitize_text_field( $_GET['fast_order_created'] ) : false; // phpcs:ignore
 
 	// Check if the order is PDP order.
 	$fast_order_is_pdp             = isset( $_GET['fast_is_pdp'] ) ? absint( $_GET['fast_is_pdp'] ) : false; // phpcs:ignore
 	$fast_redirect_after_pdp_order = get_option( FASTWC_SETTING_REDIRECT_AFTER_PDP, false );
 
 	if (
-		! empty( $fast_order_id ) &&
+		! empty( $order_id ) &&
 		(
 			(
 				$fast_order_is_pdp &&
@@ -292,9 +292,6 @@ function fastwc_maybe_clear_cart_and_redirect() {
 			// Only change the redirect URL if the redirect page URL is valid.
 			$redirect_url = ! empty( $redirect_page_url ) ? $redirect_page_url : $redirect_url;
 		}
-
-		// Get order ID from Fast order ID.
-		$order_id = fastwc_get_order_id_by_fast_order_id( $fast_order_id );
 
 		/**
 		 * Apply filters to the redirect URL and include the Order ID so that

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -247,14 +247,35 @@ function fastwc_order_status_trash_to_on_hold( $order_id, $order ) {
 add_action( 'woocommerce_order_status_trash_to_on-hold', 'fastwc_order_status_trash_to_on_hold', 10, 2 );
 
 /**
- * Clear the cart if `fast_order_created={ORDER_ID}` is added to the URL.
+ * Maybe clear the cart and redirect if `fast_order_created={ORDER_ID}` is added to the URL.
  */
 function fastwc_maybe_clear_cart_and_redirect() {
 	// Get the order ID from the `fast_order_created` query parameter in the URL, or set it to false.
-	$order_id = isset( $_GET['fast_order_created'] ) ? absint( $_GET['fast_order_created'] ) : false; // phpcs:ignore
+	$fast_order_id     = isset( $_GET['fast_order_created'] ) ? sanitize_text_field( $_GET['fast_order_created'] ) : false; // phpcs:ignore
 
-	if ( ! empty( $order_id ) ) {
+	// Check if the order is PDP order.
+	$fast_order_is_pdp             = isset( $_GET['fast_is_pdp'] ) ? absint( $_GET['fast_is_pdp'] ) ? false; // phpcs:ignore
+	$fast_redirect_after_pdp_order = get_option( FASTWC_SETTING_REDIRECT_AFTER_PDP, false );
+
+	if (
+		! empty( $fast_order_id ) &&
+		(
+			(
+				$fast_order_is_pdp &&
+				$fast_redirect_after_pdp_order
+			) ||
+			! $fast_order_is_pdp
+		)
+	) {
+		$fast_clear_cart_after_pdp_order = get_option( FASTWC_SETTING_CLEAR_CART_AFTER_PDP, false );
 		if (
+			(
+				(
+					$fast_order_is_pdp &&
+					$fast_clear_cart_after_pdp_order
+				) ||
+				! $fast_order_is_pdp
+			)
 			! empty( WC()->cart ) &&
 			is_callable( array( WC()->cart, 'empty_cart' ) )
 		) {


### PR DESCRIPTION
# Description

See [PINT-890](https://fastaf.atlassian.net/browse/PINT-890). Update the redirect URL functionality to include a filter to allow site owners to customize the redirect URL for after an order is created.

# Testing instructions

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`