### PR TITLE
Use get_query_var instead of $_GET

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -255,6 +255,7 @@ add_action( 'woocommerce_order_status_trash_to_on-hold', 'fastwc_order_status_tr
  */
 function fastwc_register_query_vars( $vars ) {
 	$vars[] = 'fast_order_created';
+	$vars[] = 'fast_order_id';
 	$vars[] = 'fast_is_pdp';
 	return $vars;
 }
@@ -266,6 +267,9 @@ add_filter( 'query_vars', 'fastwc_register_query_vars' );
 function fastwc_maybe_clear_cart_and_redirect() {
 	// Get the order ID from the `fast_order_created` query parameter in the URL, or set it to false.
 	$order_id = get_query_var( 'fast_order_created', false );
+
+	// Get the Fast order ID.
+	$fast_order_id = get_query_var( 'fast_order_id', false );
 
 	// Check if the order is PDP order.
 	$fast_order_is_pdp             = get_query_var( 'fast_is_pdp', false );
@@ -311,12 +315,14 @@ function fastwc_maybe_clear_cart_and_redirect() {
 		 * Apply filters to the redirect URL and include the Order ID so that
 		 * a custom redirect URL can be created based on the Order ID.
 		 *
-		 * @param string $redirect_url The redirect URL.
-		 * @param int    $order_id     The order ID.
+		 * @param string $redirect_url      The redirect URL.
+		 * @param int    $order_id          The order ID passed in through the URL.
+		 * @param string $fast_order_id     The Fast order ID passed in through the URL.
+		 * @param bool   $fast_order_is_pdp Flag for PDP orders.
 		 *
 		 * @return string
 		 */
-		$redirect_url = apply_filters( 'fastwc_order_created_redirect_url', $redirect_url, $order_id );
+		$redirect_url = apply_filters( 'fastwc_order_created_redirect_url', $redirect_url, $order_id, $fast_order_id, $fast_order_is_pdp );
 
 		wp_safe_redirect( $redirect_url );
 	}

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -247,14 +247,28 @@ function fastwc_order_status_trash_to_on_hold( $order_id, $order ) {
 add_action( 'woocommerce_order_status_trash_to_on-hold', 'fastwc_order_status_trash_to_on_hold', 10, 2 );
 
 /**
+ * Register custom query vars
+ *
+ * @param array $vars The array of available query variables
+ * 
+ * @link https://codex.wordpress.org/Plugin_API/Filter_Reference/query_vars
+ */
+function fastwc_register_query_vars( $vars ) {
+	$vars[] = 'fast_order_created';
+	$vars[] = 'fast_is_pdp';
+	return $vars;
+}
+add_filter( 'query_vars', 'fastwc_register_query_vars' );
+
+/**
  * Maybe clear the cart and redirect if `fast_order_created={ORDER_ID}` is added to the URL.
  */
 function fastwc_maybe_clear_cart_and_redirect() {
 	// Get the order ID from the `fast_order_created` query parameter in the URL, or set it to false.
-	$order_id = isset( $_GET['fast_order_created'] ) ? sanitize_text_field( $_GET['fast_order_created'] ) : false; // phpcs:ignore
+	$order_id = get_query_var( 'fast_order_created', false );
 
 	// Check if the order is PDP order.
-	$fast_order_is_pdp             = isset( $_GET['fast_is_pdp'] ) ? absint( $_GET['fast_is_pdp'] ) : false; // phpcs:ignore
+	$fast_order_is_pdp             = get_query_var( 'fast_is_pdp', false );
 	$fast_redirect_after_pdp_order = get_option( FASTWC_SETTING_REDIRECT_AFTER_PDP, false );
 
 	if (

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -321,7 +321,7 @@ function fastwc_maybe_clear_cart_and_redirect() {
 		wp_safe_redirect( $redirect_url );
 	}
 }
-add_action( 'init', 'fastwc_maybe_clear_cart_and_redirect' );
+add_action( 'template_redirect', 'fastwc_maybe_clear_cart_and_redirect' );
 
 /**
  * Get the WC order ID by the Fast order ID.

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -313,3 +313,14 @@ function fastwc_use_dark_mode( $product_id = 0 ) {
 
 	return $use_dark_mode;
 }
+
+/**
+ * Get the Fast order ID from the WooCommerce order ID.
+ *
+ * @param int $wc_order_id The WooCommerce order ID.
+ *
+ * @return string
+ */
+function fastwc_get_fast_order_id_from_woocommerce_order_id( $wc_order_id ) {
+	return ! empty( $wc_order_id ) ? get_post_meta( $wc_order_id, 'fast_order_id', true ) : '';
+}


### PR DESCRIPTION
# Description

Some hosts don't allow direct access to the `$_GET` variable, so this update uses WordPress' `get_query_var` function instead. Also add `fast_order_id` parameter to URL and include it in the redirect URL filter.

# Testing instructions

1. Go to https://fasttestdev.wpcomstaging.com/product/album/?fast_order_created=123456&fast_is_pdp=1
2. Verify that it redirects to https://fasttestdev.wpcomstaging.com/cart-checkout-redirect-page/?order_id=123456

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`