### PR TITLE
Fix PHP notice

### DIFF
--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -361,7 +361,7 @@ function fastwc_get_order_id_by_fast_order_id( $fast_order_id ) {
  *
  * @return array
  */
-function fastwc_woocommerce_order_data_store_cpt_get_orders_query() {
+function fastwc_woocommerce_order_data_store_cpt_get_orders_query( $query, $query_vars ) {
 	if ( ! empty( $query_vars['fast_order_id'] ) ) {
 		$query['meta_query'][] = array(
 			'key'   => 'fast_order_id',


### PR DESCRIPTION
# Description

Fix a PHP notice about undefined variables.

# Testing instructions

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`