### PR TITLE
PINT-979 - Add hooks

### DIFF
--- a/includes/blocks/class-block.php
+++ b/includes/blocks/class-block.php
@@ -90,7 +90,21 @@ abstract class Block {
 		) {
 			ob_start();
 
+			/**
+			 * Action to be triggered before a block is rendered.
+			 *
+			 * @param string $template The name of the block template being rendered.
+			 */
+			\do_action( 'fastwc_before_render_block', $this->teplate );
+
 			\fastwc_load_template( $this->template, $attributes );
+
+			/**
+			 * Action to be triggered after a block is rendered.
+			 *
+			 * @param string $template The name of the block template being rendered.
+			 */
+			\do_action( 'fastwc_after_render_block', $this->teplate );
 
 			$block_output = ob_get_clean();
 		}

--- a/includes/blocks/class-block.php
+++ b/includes/blocks/class-block.php
@@ -104,7 +104,7 @@ abstract class Block {
 			 *
 			 * @param string $template The name of the block template being rendered.
 			 */
-			\do_action( 'fastwc_after_render_block', $this->teplate );
+			\do_action( 'fastwc_after_render_block', $this->template );
 
 			$block_output = ob_get_clean();
 		}

--- a/includes/blocks/class-block.php
+++ b/includes/blocks/class-block.php
@@ -95,7 +95,7 @@ abstract class Block {
 			 *
 			 * @param string $template The name of the block template being rendered.
 			 */
-			\do_action( 'fastwc_before_render_block', $this->teplate );
+			\do_action( 'fastwc_before_render_block', $this->template );
 
 			\fastwc_load_template( $this->template, $attributes );
 

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -280,8 +280,8 @@ add_action( 'woocommerce_order_status_trash_to_on-hold', 'fastwc_order_status_tr
 /**
  * Register custom query vars
  *
- * @param array $vars The array of available query variables
- * 
+ * @param array $vars The array of available query variables.
+ *
  * @link https://codex.wordpress.org/Plugin_API/Filter_Reference/query_vars
  */
 function fastwc_register_query_vars( $vars ) {

--- a/includes/checkout.php
+++ b/includes/checkout.php
@@ -12,10 +12,18 @@ require_once FASTWC_PATH . 'includes/hide.php';
 
 /**
  * Returns cart item data that Fast Checkout button can interpret.
- * This function also populates some global variables about cart state, such as whether it contains products we don't support.
+ * This function also populates some global variables about cart state,
+ * such as whether it contains products we don't support.
+ *
+ * @return array
  */
 function fastwc_get_cart_data() {
 	$fastwc_cart_data = array();
+
+	/**
+	 * Action triggered before cart data is fetched.
+	 */
+	do_action( 'fastwc_before_get_cart_data' );
 
 	if ( ! empty( WC()->cart ) ) {
 		foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
@@ -44,6 +52,13 @@ function fastwc_get_cart_data() {
 		fastwc_log_debug( 'Fetched cart data: ' . print_r( $fastwc_cart_data, true ) ); // phpcs:ignore
 	}
 
+	/**
+	 * Action triggered after cart data is fetched.
+	 *
+	 * @param array $fastwc_cart_data The cart data that is fetched.
+	 */
+	do_action( 'fastwc_after_get_cart_data', $fastwc_cart_data );
+
 	return $fastwc_cart_data;
 }
 
@@ -65,7 +80,23 @@ function fastwc_maybe_render_checkout_button( $button_type, $template ) {
 		return;
 	}
 
+	/**
+	 * Action triggered before loading the checkout button.
+	 *
+	 * @param string $button_type The type of button. Should be either 'pdp' or 'cart'.
+	 * @param string $template    The template to render.
+	 */
+	do_action( 'fastwc_before_render_checkout_button', $button_type, $template );
+
 	fastwc_load_template( $template );
+
+	/**
+	 * Action triggered after loading the checkout button.
+	 *
+	 * @param string $button_type The type of button. Should be either 'pdp' or 'cart'.
+	 * @param string $template    The template that was rendered.
+	 */
+	do_action( 'fastwc_after_render_checkout_button', $button_type, $template );
 }
 
 /**
@@ -390,6 +421,15 @@ function fastwc_maybe_hide_proceed_to_checkout_buttons() {
 	}
 
 	$hide_regular_checkout_buttons = get_option( FASTWC_SETTING_HIDE_REGULAR_CHECKOUT_BUTTONS, false );
+
+	/**
+	 * Filter flag to hide regular checkout buttons.
+	 *
+	 * @param bool $hide_regular_checkout_buttons The flag to hide regular checkout buttons.
+	 *
+	 * @return bool
+	 */
+	$hide_regular_checkout_buttons = apply_filters( 'fastwc_hide_regular_checkout_buttons', $hide_regular_checkout_buttons );
 
 	if ( $hide_regular_checkout_buttons ) {
 		remove_action( 'woocommerce_proceed_to_checkout', 'woocommerce_button_proceed_to_checkout', 20 );

--- a/includes/login.php
+++ b/includes/login.php
@@ -27,7 +27,17 @@ function fastwc_add_login_to_footer() {
 	$show_in_footer = get_option( FASTWC_SETTING_SHOW_LOGIN_BUTTON_FOOTER, 1 );
 
 	if ( ! empty( $show_in_footer ) ) {
+		/**
+		 * Action to trigger before the Fast login button is added to the footer.
+		 */
+		do_action( 'fastwc_before_add_login_to_footer' );
+
 		fastwc_load_template( 'fast-login' );
+
+		/**
+		 * Action to trigger after the Fast login button is added to the footer.
+		 */
+		do_action( 'fastwc_after_add_login_to_footer' );
 
 		fastwc_log_info( 'Loaded login template' );
 	}
@@ -102,6 +112,7 @@ function fastwc_login_init() {
 	header( 'Expires: Mon, 01 Jan 1990 01:00:00 GMT' );
 
 	wp_safe_redirect( 'https://' . wp_unslash( $_SERVER['HTTP_HOST'] ) . $target_page . $get_query );
+	exit;
 }
 add_action( 'init', 'fastwc_login_init' );
 

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -93,6 +93,9 @@ function fastwc_shortcode_button_template( $template, $atts ) {
 
 	fastwc_log_info( 'Rendering shortcode template: ' . $template );
 
+	// Start the output buffer.
+	ob_start();
+
 	/**
 	 * Action that triggers before a shortcode template is rendered.
 	 *
@@ -100,13 +103,8 @@ function fastwc_shortcode_button_template( $template, $atts ) {
 	 */
 	do_action( 'fastwc_before_render_shortcode', $template );
 
-	// Start the output buffer.
-	ob_start();
-
 	// Load the button template, passing in `$atts` as the template's `$args`.
 	fastwc_load_template( $template, $atts );
-
-	$shortcode_output = ob_get_clean();
 
 	/**
 	 * Action that triggers after a shortcode template is rendered.
@@ -115,5 +113,5 @@ function fastwc_shortcode_button_template( $template, $atts ) {
 	 */
 	do_action( 'fastwc_after_render_shortcode', $template );
 
-	return $shortcode_output;
+	return ob_get_clean();
 }

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -93,11 +93,27 @@ function fastwc_shortcode_button_template( $template, $atts ) {
 
 	fastwc_log_info( 'Rendering shortcode template: ' . $template );
 
+	/**
+	 * Action that triggers before a shortcode template is rendered.
+	 *
+	 * @param string $template The name of the shortcode template.
+	 */
+	do_action( 'fastwc_before_render_shortcode', $template );
+
 	// Start the output buffer.
 	ob_start();
 
 	// Load the button template, passing in `$atts` as the template's `$args`.
 	fastwc_load_template( $template, $atts );
 
-	return ob_get_clean();
+	$shortcode_output = ob_get_clean();
+
+	/**
+	 * Action that triggers after a shortcode template is rendered.
+	 *
+	 * @param string $template The name of the shortcode template.
+	 */
+	do_action( 'fastwc_after_render_shortcode', $template );
+
+	return $shortcode_output;
 }

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -33,7 +33,7 @@ function fastwc_load_template( $template_name, $args = array() ) {
 			 *
 			 * @param array $args Array of args that get passed to the template.
 			 */
-			do_action( "fastwc_before_load_template_{$template_name}", $args )
+			do_action( "fastwc_before_load_template_{$template_name}", $args );
 
 			/**
 			 * WordPress load_template function to load the located template.
@@ -49,7 +49,8 @@ function fastwc_load_template( $template_name, $args = array() ) {
 			 *
 			 * @param array $args Array of args that get passed to the template.
 			 */
-			do_action( "fastwc_after_load_template_{$template_name}", $args )
+			do_action( "fastwc_after_load_template_{$template_name}", $args );
+
 			fastwc_log_info( 'Loaded template: ' . $location );
 			return;
 		}

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -28,12 +28,18 @@ function fastwc_load_template( $template_name, $args = array() ) {
 	// Check each file location and load the first one that exists.
 	foreach ( $locations as $location ) {
 		if ( file_exists( $location ) ) {
+			$action_template_name = str_replace(
+				array( '/', '-' ),
+				'_',
+				$template_name
+			);
+
 			/**
 			 * Action hook to trigger before loading the template.
 			 *
 			 * @param array $args Array of args that get passed to the template.
 			 */
-			do_action( "fastwc_before_load_template_{$template_name}", $args );
+			do_action( "fastwc_before_load_template_{$action_template_name}", $args );
 
 			/**
 			 * WordPress load_template function to load the located template.
@@ -49,7 +55,7 @@ function fastwc_load_template( $template_name, $args = array() ) {
 			 *
 			 * @param array $args Array of args that get passed to the template.
 			 */
-			do_action( "fastwc_after_load_template_{$template_name}", $args );
+			do_action( "fastwc_after_load_template_{$action_template_name}", $args );
 
 			fastwc_log_info( 'Loaded template: ' . $location );
 			return;

--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -29,6 +29,13 @@ function fastwc_load_template( $template_name, $args = array() ) {
 	foreach ( $locations as $location ) {
 		if ( file_exists( $location ) ) {
 			/**
+			 * Action hook to trigger before loading the template.
+			 *
+			 * @param array $args Array of args that get passed to the template.
+			 */
+			do_action( "fastwc_before_load_template_{$template_name}", $args )
+
+			/**
 			 * WordPress load_template function to load the located template.
 			 *
 			 * @param string $location     Location of the template to load.
@@ -36,6 +43,13 @@ function fastwc_load_template( $template_name, $args = array() ) {
 			 * @param array  $args         Array of args to pass to the tepmlate. Requires WP 5.5+.
 			 */
 			load_template( $location, false, $args );
+
+			/**
+			 * Action hook to trigger after loading the template.
+			 *
+			 * @param array $args Array of args that get passed to the template.
+			 */
+			do_action( "fastwc_after_load_template_{$template_name}", $args )
 			fastwc_log_info( 'Loaded template: ' . $location );
 			return;
 		}
@@ -54,7 +68,16 @@ function fastwc_get_pdp_button_hook() {
 		$fastwc_pdp_button_hook = get_option( FASTWC_SETTING_PDP_BUTTON_HOOK_OTHER, FASTWC_DEFAULT_PDP_BUTTON_HOOK );
 	}
 
-	return ! empty( $fastwc_pdp_button_hook ) ? $fastwc_pdp_button_hook : FASTWC_DEFAULT_PDP_BUTTON_HOOK;
+	$fastwc_pdp_button_hook = ! empty( $fastwc_pdp_button_hook ) ? $fastwc_pdp_button_hook : FASTWC_DEFAULT_PDP_BUTTON_HOOK;
+
+	/**
+	 * Filter to overrie the Fast PDP button hook.
+	 *
+	 * @param string $fastwc_pdp_button_hook The selected PDP button hook.
+	 *
+	 * @return string
+	 */
+	return apply_filters( 'fastwc_pdp_button_hook', $fastwc_pdp_button_hook );
 }
 
 /**
@@ -75,7 +98,14 @@ function fastwc_get_products_to_hide_buttons() {
 		fastwc_log_info( 'Products fetched to hide buttons: ' . print_r( $fastwc_hidden_products, true ) ); // phpcs:ignore
 	}
 
-	return $fastwc_hidden_products;
+	/**
+	 * Filter to override the list of products for which the button should be hidden.
+	 *
+	 * @param array $fastwc_hidden_products The list of products for which the button should be hidden.
+	 *
+	 * @return array
+	 */
+	return apply_filters( 'fastwc_hidden_products', $fastwc_hidden_products );
 }
 
 /**

--- a/includes/widgets/class-widget.php
+++ b/includes/widgets/class-widget.php
@@ -45,7 +45,21 @@ class Widget extends \WP_Widget {
 			'instance' => $instance,
 		);
 
+		/**
+		 * Action to trigger before rendering a widget.
+		 *
+		 * @param string $template The template of the widget to render.
+		 */
+		\do_action( 'fastwc_before_render_widget', $this->template );
+
 		\fastwc_load_template( 'widgets/fast-widget', $widget_data );
+
+		/**
+		 * Action to trigger after rendering a widget.
+		 *
+		 * @param string $template The template of the widget that was rendered.
+		 */
+		\do_action( 'fastwc_after_render_widget', $this->template );
 	}
 
 	/**


### PR DESCRIPTION
# Description

Add hooks to strategic parts of the code to better enable customization by 3rd-party developers.

# Testing instructions

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`