### PR TITLE
PINT-991 - Update seller signup url

### DIFF
--- a/fast.php
+++ b/fast.php
@@ -21,6 +21,8 @@ require_once FASTWC_PATH . 'includes/version.php';
 
 // Check whether the woocommerce plugin is active.
 if ( fastwc_woocommerce_is_active() ) {
+	// Fast upgrade functions.
+	require_once FASTWC_PATH . 'includes/upgrade.php';
 	// Fast debug functions.
 	require_once FASTWC_PATH . 'includes/debug.php';
 	// WP Admin plugin settings.

--- a/includes/admin/constants.php
+++ b/includes/admin/constants.php
@@ -12,6 +12,7 @@ define( 'FASTWC_SETTING_TEST_MODE_USERS', 'fastwc_test_mode_users' );
 define( 'FASTWC_SETTING_FAST_JS_URL', 'fast_fast_js_url' );
 define( 'FASTWC_SETTING_FAST_JWKS_URL', 'fast_fast_jwks_url' );
 define( 'FASTWC_SETTING_ONBOARDING_URL', 'fast_onboarding_url' );
+define( 'FASTWC_SETTING_DASHBOARD_URL', 'fastwc_dashboard_url' );
 define( 'FASTWC_SETTING_DEBUG_MODE', 'fastwc_debug_mode' );
 define( 'FASTWC_SETTING_DEBUG_MODE_NOT_SET', 'fast debug mode not set' );
 define( 'FASTWC_SETTING_LOAD_BUTTON_STYLES', 'fastwc_load_button_styles' );
@@ -39,6 +40,7 @@ define( 'FASTWC_SETTING_PLUGIN_DO_INIT_FORMAT', 'fastwc_do_init_%s' );
 define( 'FASTWC_JWKS_URL', 'https://api.fast.co/v1/oauth2/jwks' );
 define( 'FASTWC_JS_URL', 'https://js.fast.co/fast-woocommerce.js' );
 define( 'FASTWC_ONBOARDING_URL', 'https://fast.co/business-sign-up' );
+define( 'FASTWC_DASHBOARD_URL', 'https://fast.co/business' );
 define( 'FASTWC_SETTINGS_TIMESTAMPS', 'fastwc_settings_timestamps' );
 
 define(

--- a/includes/admin/constants.php
+++ b/includes/admin/constants.php
@@ -38,7 +38,7 @@ define( 'FASTWC_SETTING_HIDE_REGULAR_CHECKOUT_BUTTONS', 'fastwc_hide_regular_che
 define( 'FASTWC_SETTING_PLUGIN_DO_INIT_FORMAT', 'fastwc_do_init_%s' );
 define( 'FASTWC_JWKS_URL', 'https://api.fast.co/v1/oauth2/jwks' );
 define( 'FASTWC_JS_URL', 'https://js.fast.co/fast-woocommerce.js' );
-define( 'FASTWC_ONBOARDING_URL', 'https://fast.co/business' );
+define( 'FASTWC_ONBOARDING_URL', 'https://fast.co/business-sign-up' );
 define( 'FASTWC_SETTINGS_TIMESTAMPS', 'fastwc_settings_timestamps' );
 
 define(

--- a/includes/admin/settings.php
+++ b/includes/admin/settings.php
@@ -31,6 +31,7 @@ function fastwc_updated_option( $option, $old_value, $value ) {
 		FASTWC_SETTING_FAST_JS_URL,
 		FASTWC_SETTING_FAST_JWKS_URL,
 		FASTWC_SETTING_ONBOARDING_URL,
+		FASTWC_SETTING_DASHBOARD_URL,
 		FASTWC_SETTING_PDP_BUTTON_STYLES,
 		FASTWC_SETTING_CART_BUTTON_STYLES,
 		FASTWC_SETTING_MINI_CART_BUTTON_STYLES,
@@ -236,6 +237,7 @@ function fastwc_admin_setup_sections() {
 		register_setting( $section_name, FASTWC_SETTING_FAST_JS_URL );
 		register_setting( $section_name, FASTWC_SETTING_FAST_JWKS_URL );
 		register_setting( $section_name, FASTWC_SETTING_ONBOARDING_URL );
+		register_setting( $section_name, FASTWC_SETTING_DASHBOARD_URL );
 	}
 }
 
@@ -282,6 +284,7 @@ function fastwc_admin_setup_fields() {
 	add_settings_field( FASTWC_SETTING_FAST_JS_URL, __( 'Fast JS URL', 'fast' ), 'fastwc_fastwc_js_content', $settings_section, $settings_section );
 	add_settings_field( FASTWC_SETTING_FAST_JWKS_URL, __( 'Fast JWKS URL', 'fast' ), 'fastwc_fastwc_jwks_content', $settings_section, $settings_section );
 	add_settings_field( FASTWC_SETTING_ONBOARDING_URL, __( 'Fast Onboarding URL', 'fast' ), 'fastwc_onboarding_url_content', $settings_section, $settings_section );
+	add_settings_field( FASTWC_SETTING_DASHBOARD_URL, __( 'Fast Seller Dashboard URL', 'fast' ), 'fastwc_dashboard_url_content', $settings_section, $settings_section );
 }
 
 /**
@@ -770,7 +773,21 @@ function fastwc_onboarding_url_content() {
 
 	fastwc_settings_field_input(
 		array(
-			'name'  => 'fast_onboarding_url',
+			'name'  => FASTWC_SETTING_ONBOARDING_URL,
+			'value' => $url,
+		)
+	);
+}
+
+/**
+ * Renders the dashboard URL field.
+ */
+function fastwc_dashboard_url_content() {
+	$url = fastwc_get_option_or_set_default( FASTWC_SETTING_DASHBOARD_URL, FASTWC_DASHBOARD_URL );
+
+	fastwc_settings_field_input(
+		array(
+			'name'  => FASTWC_SETTING_DASHBOARD_URL,
 			'value' => $url,
 		)
 	);

--- a/includes/upgrade.php
+++ b/includes/upgrade.php
@@ -37,30 +37,36 @@ add_action( 'admin_init', 'fastwc_handle_upgrades' );
 function fastwc_handle_1_1_16_upgrades() {
 	// Update the onboarding URL setting value.
 	$onboarding_url = get_option( FASTWC_SETTING_ONBOARDING_URL );
+	$dashboard_url  = get_option( FASTWC_SETTING_DASHBOARD_URL );
 
 	switch ( $onboarding_url ) {
 		// Staging URL.
 		case 'https://fast-site.staging.slowfast.co/business':
 		case 'https://fast-site.staging.slowfast.co/business/':
-			$onboarding_url = 'fast-site.staging.slowfast.co/business-sign-up';
+			$onboarding_url = 'https://fast-site.staging.slowfast.co/business-sign-up';
+			$dashboard_url  = 'https://fast-site.staging.slowfast.co/business';
 			break;
 
 		//  Sandbox URL.
 		case 'https://fast-site.sandbox.fast.co/business':
 		case 'https://fast-site.sandbox.fast.co/business/':
-			$onboarding_url = 'fast-site.sandbox.fast.co/business-sign-up';
+			$onboarding_url = 'https://fast-site.sandbox.fast.co/business-sign-up';
+			$dashboard_url  = 'https://fast-site.sandbox.fast.co/business';
 			break;
 
 		// Dev URL.
 		case 'https://fast-site.dev.slow.dev/business':
 		case 'https://fast-site.dev.slow.dev/business/':
-			$onboarding_url = 'fast-site.dev.slow.dev/business-sign-up';
+			$onboarding_url = 'https://fast-site.dev.slow.dev/business-sign-up';
+			$dashboard_url  = 'https://fast-site.dev.slow.dev/business';
 			break;
 
 		default:
 			$onboarding_url = FASTWC_ONBOARDING_URL;
+			$dashboard_url  = FASTWC_DASHBOARD_URL;
 			break;
 	}
 
 	update_option( FASTWC_SETTING_ONBOARDING_URL, $onboarding_url );
+	update_option( FASTWC_SETTING_DASHBOARD_URL, $dashboard_url );
 }

--- a/includes/upgrade.php
+++ b/includes/upgrade.php
@@ -47,7 +47,7 @@ function fastwc_handle_1_1_16_upgrades() {
 			$dashboard_url  = 'https://fast-site.staging.slowfast.co/business';
 			break;
 
-		//  Sandbox URL.
+		// Sandbox URL.
 		case 'https://fast-site.sandbox.fast.co/business':
 		case 'https://fast-site.sandbox.fast.co/business/':
 			$onboarding_url = 'https://fast-site.sandbox.fast.co/business-sign-up';

--- a/includes/upgrade.php
+++ b/includes/upgrade.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Utility to handle any updates needed when upgrading to a new version of the plugin.
+ *
+ * @package Fast
+ */
+
+// Define a key to use for the Fast version option.
+define( 'FASTWC_OPTION_VERSION', 'fastwc_version' );
+
+/**
+ * Handle Fast Checkout for WooCommerce upgrades.
+ */
+function fastwc_handle_upgrades() {
+	$previous_version = get_option( FASTWC_OPTION_VERSION );
+
+	if ( empty( $previous_version ) ) {
+		$previous_version = '1.1.15';
+		add_option( FASTWC_OPTION_VERSION, $previous_version );
+	}
+
+	// Maybe handle the upgrade to version 1.1.16.
+	if ( version_compare( $previous_version, '1.1.16', '<' ) ) {
+		fastwc_handle_1_1_16_upgrades();
+	}
+
+	// Store the current version of the Fast Checkout for WooCommerce plugin.
+	if ( version_compare( FASTWC_VERSION, $previous_version, '!=' ) ) {
+		update_option( FASTWC_OPTION_VERSION, FASTWC_VERSION );
+	}
+}
+add_action( 'admin_init', 'fastwc_handle_upgrades' );
+
+/**
+ * Handle the upgrade to version 1.1.16.
+ */
+function fastwc_handle_1_1_16_upgrades() {
+	// Update the onboarding URL setting value.
+	$onboarding_url = get_option( FASTWC_SETTING_ONBOARDING_URL );
+
+	switch ( $onboarding_url ) {
+		// Staging URL.
+		case 'https://fast-site.staging.slowfast.co/business':
+		case 'https://fast-site.staging.slowfast.co/business/':
+			$onboarding_url = 'fast-site.staging.slowfast.co/business-sign-up';
+			break;
+
+		//  Sandbox URL.
+		case 'https://fast-site.sandbox.fast.co/business':
+		case 'https://fast-site.sandbox.fast.co/business/':
+			$onboarding_url = 'fast-site.sandbox.fast.co/business-sign-up';
+			break;
+
+		// Dev URL.
+		case 'https://fast-site.dev.slow.dev/business':
+		case 'https://fast-site.dev.slow.dev/business/':
+			$onboarding_url = 'fast-site.dev.slow.dev/business-sign-up';
+			break;
+
+		default:
+			$onboarding_url = FASTWC_ONBOARDING_URL;
+			break;
+	}
+
+	update_option( FASTWC_SETTING_ONBOARDING_URL, $onboarding_url );
+}

--- a/includes/upgrade.php
+++ b/includes/upgrade.php
@@ -39,32 +39,18 @@ function fastwc_handle_1_1_16_upgrades() {
 	$onboarding_url = get_option( FASTWC_SETTING_ONBOARDING_URL );
 	$dashboard_url  = get_option( FASTWC_SETTING_DASHBOARD_URL );
 
-	switch ( $onboarding_url ) {
-		// Staging URL.
-		case 'https://fast-site.staging.slowfast.co/business':
-		case 'https://fast-site.staging.slowfast.co/business/':
-			$onboarding_url = 'https://fast-site.staging.slowfast.co/business-sign-up';
-			$dashboard_url  = 'https://fast-site.staging.slowfast.co/business';
-			break;
-
-		// Sandbox URL.
-		case 'https://fast-site.sandbox.fast.co/business':
-		case 'https://fast-site.sandbox.fast.co/business/':
-			$onboarding_url = 'https://fast-site.sandbox.fast.co/business-sign-up';
-			$dashboard_url  = 'https://fast-site.sandbox.fast.co/business';
-			break;
-
-		// Dev URL.
-		case 'https://fast-site.dev.slow.dev/business':
-		case 'https://fast-site.dev.slow.dev/business/':
-			$onboarding_url = 'https://fast-site.dev.slow.dev/business-sign-up';
-			$dashboard_url  = 'https://fast-site.dev.slow.dev/business';
-			break;
-
-		default:
-			$onboarding_url = FASTWC_ONBOARDING_URL;
-			$dashboard_url  = FASTWC_DASHBOARD_URL;
-			break;
+	if ( false !== strpos( $onboarding_url, 'staging' ) ) {
+		$onboarding_url = 'https://fast-site.staging.slowfast.co/business-sign-up';
+		$dashboard_url  = 'https://fast-site.staging.slowfast.co/business';
+	} elseif ( false !== strpos( $onboarding_url, 'sandbox' ) ) {
+		$onboarding_url = 'https://fast-site.sandbox.fast.co/business-sign-up';
+		$dashboard_url  = 'https://fast-site.sandbox.fast.co/business';
+	} elseif ( false !== strpos( $onboarding_url, 'dev' ) ) {
+		$onboarding_url = 'https://fast-site.dev.slow.dev/business-sign-up';
+		$dashboard_url  = 'https://fast-site.dev.slow.dev/business';
+	} else {
+		$onboarding_url = FASTWC_ONBOARDING_URL;
+		$dashboard_url  = FASTWC_DASHBOARD_URL;
 	}
 
 	update_option( FASTWC_SETTING_ONBOARDING_URL, $onboarding_url );

--- a/templates/admin/fast-settings-footer.php
+++ b/templates/admin/fast-settings-footer.php
@@ -40,7 +40,6 @@ $fastwc_app_id                      = fastwc_get_app_id();
 				<?php esc_html_e( 'Seller Login', 'fast' ); ?>
 			</a>
 		</li>
-		<?php endif; ?>
 		<li class="fast-footer-link">
 			<a href="https://www.fast.co/home" target="_blank" rel="noopener" title="<?php esc_attr_e( 'Learn more about Fast', 'fast' ); ?>">
 				<?php esc_html_e( 'About', 'fast' ); ?>

--- a/templates/admin/fast-settings-footer.php
+++ b/templates/admin/fast-settings-footer.php
@@ -6,6 +6,8 @@
  */
 
 $fastwc_setting_fast_onboarding_url = fastwc_get_option_or_set_default( FASTWC_SETTING_ONBOARDING_URL, FASTWC_ONBOARDING_URL );
+$fastwc_setting_fast_dashboard_url  = fastwc_get_option_or_set_default( FASTWC_SETTING_DASHBOARD_URL, FASTWC_DASHBOARD_URL );
+$fastwc_app_id                      = fastwc_get_app_id();
 ?>
 
 <div class="fast-footer">
@@ -26,11 +28,19 @@ $fastwc_setting_fast_onboarding_url = fastwc_get_option_or_set_default( FASTWC_S
 				?>
 			</a>
 		</li>
+		<?php if ( empty( $fastwc_app_id ) ) : ?>
 		<li class="fast-footer-link">
-			<a href="<?php echo esc_url( $fastwc_setting_fast_onboarding_url ); ?>" target="_blank" rel="noopener" title="<?php esc_attr_e( 'Login to the Fast Seller Dashboard', 'fast' ); ?>">
+			<a href="<?php echo esc_url( $fastwc_setting_fast_onboarding_url ); ?>" target="_blank" rel="noopener" title="<?php esc_attr_e( 'Become a Seller', 'fast' ); ?>">
+				<?php esc_html_e( 'Become a Seller', 'fast' ); ?>
+			</a>
+		</li>
+		<?php endif; ?>
+		<li class="fast-footer-link">
+			<a href="<?php echo esc_url( $fastwc_setting_fast_dashboard_url ); ?>" target="_blank" rel="noopener" title="<?php esc_attr_e( 'Login to the Fast Seller Dashboard', 'fast' ); ?>">
 				<?php esc_html_e( 'Seller Login', 'fast' ); ?>
 			</a>
 		</li>
+		<?php endif; ?>
 		<li class="fast-footer-link">
 			<a href="https://www.fast.co/home" target="_blank" rel="noopener" title="<?php esc_attr_e( 'Learn more about Fast', 'fast' ); ?>">
 				<?php esc_html_e( 'About', 'fast' ); ?>


### PR DESCRIPTION
# Description

Update the onboarding URL to the new seller signup URL.

# Testing instructions

1. Login to staging.
2. Verify that the new seller signup URL is being used instead of the dashboard (/business) URL.

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`