### PR TITLE
Update webhooks check

### DIFF
--- a/includes/webhooks.php
+++ b/includes/webhooks.php
@@ -232,7 +232,7 @@ function fastwc_maybe_clear_fast_webhooks_cache() {
 		return;
 	}
 
-	fast_clear_webhooks_cache();
+	fastwc_clear_webhooks_cache();
 }
 add_action( 'init', 'fastwc_maybe_clear_fast_webhooks_cache' );
 

--- a/includes/webhooks.php
+++ b/includes/webhooks.php
@@ -232,7 +232,7 @@ function fastwc_maybe_clear_fast_webhooks_cache() {
 		return;
 	}
 
-	fastwc_clear_webhooks_cache();
+	fastwc_clear_fast_webhooks_cache();
 }
 add_action( 'init', 'fastwc_maybe_clear_fast_webhooks_cache' );
 

--- a/includes/webhooks.php
+++ b/includes/webhooks.php
@@ -50,7 +50,7 @@ add_action( 'woocommerce_webhook_options_save', 'fastwc_woocommerce_webhook_opti
  * @return bool
  */
 function fastwc_is_disabled_webhook( $webhook ) {
-	return 'disabled' === $webhook->get_status();
+	return ! empty( $webhook ) && 'disabled' === $webhook->get_status();
 }
 
 /**
@@ -96,7 +96,7 @@ function fastwc_get_disabled_webhooks() {
 		foreach ( $disabled_webhooks as $webhook_topic => $webhook_id ) {
 			$webhook = wc_get_webhook( $webhook_id );
 
-			if ( ! empty( $webhook ) && ! fastwc_is_disabled_webhook( $webhook ) ) {
+			if ( ! fastwc_is_disabled_webhook( $webhook ) ) {
 				unset( $disabled_webhooks[ $webhook_topic ] );
 				$did_unset = true;
 			}


### PR DESCRIPTION
# Description

This update fixes some small issues with the webhook status check.

# Testing instructions

1. Login to staging.
2. Go to the Fast status tab.
3. Verify that the webhooks status is displaying correctly.

# Checks
- [x] Code has been formatted with `phpcbf --standard WordPress`
- [x] No new linter warnings from `phpcs --standard WordPress`